### PR TITLE
Added multiline subtitles support for auto-subs-light

### DIFF
--- a/auto-subs-light.py
+++ b/auto-subs-light.py
@@ -126,10 +126,17 @@ def OnAddSubs(ev):
 
       timelineStartFrame = timeline.GetStartFrame() # get timeline start frame
       #print("-> Start of timeline: ", timelineStartFrame)
-      for i in range(0, len(lines), 4):
+      i = 0
+      while i < len(lines):
          frame_rate = timeline.GetSetting("timelineFrameRate") # get timeline framerate
          start_time, end_time = lines[i+1].strip().split(" --> ")
-         text = lines[i+2].strip() # get  subtitle text
+
+         # Accumulate subtitle text until an empty line is found
+         text = lines[i+2].strip()
+         for j in range(i+3, len(lines)):
+            if lines[j].strip() == "":
+               break
+            text += "\n" + lines[j].strip()
 
          # Convert timestamps to frames for position of subtitle
          hours, minutes, seconds_milliseconds = start_time.split(':')
@@ -180,6 +187,9 @@ def OnAddSubs(ev):
                text = re.sub(pattern, censored_word, text, flags=re.IGNORECASE)
                   
          subs.append((timelinePos, duration, text)) # add subtitle to list
+
+         # Move to the next subtitle block
+         i = j + 1
       
       print("Found", len(subs), "subtitles in SRT file")
       


### PR DESCRIPTION
According to the [SRT file format](https://docs.fileformat.com/video/srt/#srt-file-structure), it is possible to have multiline subtitles (i.e., subtitles that span more than one line). However, the `auto-subs-light` script did not support this and would produce an error when encountering multiline subtitles: `not enough values to unpack (expected 2, got 1)`.

This pull request adds support for multiline subtitles.