### PR TITLE
Add spanish initial exclamation marks for 'Remove Punctuation' option

### DIFF
--- a/AutoSubs-App/src-tauri/resources/modules/utf8.lua
+++ b/AutoSubs-App/src-tauri/resources/modules/utf8.lua
@@ -2356,6 +2356,7 @@ local function classMatchGenerator(class, plain)
 				table.insert(ranges, {58, 64})
 				table.insert(ranges, {91, 96})
 				table.insert(ranges, {123, 126})
+				table.insert(codes, 161)
 			elseif c == 's' then -- %s: represents all space characters.
 				table.insert(ranges, {9, 13})
 				table.insert(codes, 32)


### PR DESCRIPTION
As a native spanish speaker, when I tested the "Remove Punctuation" function, I noticed that the auto-subs removed everything except for the '¡' (initial exclamation mark, it's diferent from the i)

this commit only adds the character in the UTF8 option to make it work.

I tested it myself with some videos I edited and works perfectly fine.