### PR TITLE
Specify install origin of MacOS DaVinci Resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Generate Subtitles & Label Speakers |  Advanced Settings
 - Open the installer and follow the on-screen instructions.
 
 ### 2. Launch AutoSubs in DaVinci Resolve
-- Open **DaVinci Resolve**.
+- Open **DaVinci Resolve**. *(If you're using MacOS, make sure you aren't using the App Store version of DaVinci Resolve.)*
 - In the top menu, go to **Workspace → Scripts → AutoSubs V2**.
 
 You’re all set! 🚀 AutoSubs V2 is now ready to generate subtitles effortlessly.


### PR DESCRIPTION
This pull request doesn't change much. It adds a short line in the README.md file, telling MacOS users to install DaVinci Resolve from Blackmagic's website instead of from the Mac App Store.

I can attest that this script functions well, but I couldn't get it working with the Mac App Store version - I had to install DaVinci Resolve from Blackmagic's website.

If this issue is fixed feel free to remove the line, but I think it's useful to have at least a disclaimer to those who want to use this script with the Mac App Store version.