### PR TITLE
fix: Audio Input improvements and multi-clip transcription

### DIFF
--- a/AutoSubs-App/src-tauri/src/config.rs
+++ b/AutoSubs-App/src-tauri/src/config.rs
@@ -1,8 +1,17 @@
 use core::fmt;
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize)]
+/// Audio segment for segment-based transcription
+/// When provided, only these portions of the audio are considered,
+/// and each segment gets its own timeline offset
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TranscribeSegment {
+    pub start: f64,           // Start time within audio file (seconds)
+    pub end: f64,             // End time within audio file (seconds)
+    pub timeline_offset: f64, // Offset to add for timeline placement (seconds)
+}
 
+#[derive(Deserialize, Serialize)]
 pub struct TranscribeOptions {
     pub path: String,
     pub offset: Option<f64>,
@@ -19,6 +28,9 @@ pub struct TranscribeOptions {
     pub max_sentence_len: Option<i32>,
     pub sampling_strategy: Option<String>,
     pub sampling_bestof_or_beam_size: Option<i32>,
+    
+    /// If provided, only transcribe these segments and apply their timeline offsets
+    pub segments: Option<Vec<TranscribeSegment>>,
 }
 
 impl fmt::Debug for TranscribeOptions {

--- a/AutoSubs-App/src-tauri/src/tests.rs
+++ b/AutoSubs-App/src-tauri/src/tests.rs
@@ -39,6 +39,7 @@ mod tests {
             enable_gpu: Some(true),
             enable_diarize: Some(false),
             max_speakers: None,
+            segments: None,
         };
 
         let res = transcribe_audio(handle, options).await;
@@ -87,6 +88,7 @@ mod tests {
             enable_gpu: Some(true),
             enable_diarize: Some(false),
             max_speakers: None,
+            segments: None,
         };
 
         let res = transcribe_audio(handle, options).await;

--- a/AutoSubs-App/src/api/resolveAPI.ts
+++ b/AutoSubs-App/src/api/resolveAPI.ts
@@ -54,7 +54,39 @@ export async function getTimelineInfo() {
   return data;
 }
 
-export async function addSubtitlesToTimeline(filename: string, currentTemplate: string, outputTrack: string) {
+export interface ConflictInfo {
+  hasConflicts: boolean;
+  conflictingClips?: Array<{ start: number; end: number; name: string }>;
+  trackName?: string;
+  subtitleRange?: { start: number; end: number };
+  totalConflicts?: number;
+  trackExists?: boolean;
+  message?: string;
+  error?: string;
+}
+
+export type ConflictMode = 'replace' | 'skip' | 'new_track' | null;
+
+export async function checkTrackConflicts(filename: string, outputTrack: string): Promise<ConflictInfo> {
+  const filePath = await getTranscriptPath(filename);
+  const response = await fetch(resolveAPI, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      func: "CheckTrackConflicts",
+      filePath,
+      trackIndex: outputTrack,
+    }),
+  });
+  return response.json();
+}
+
+export async function addSubtitlesToTimeline(
+  filename: string,
+  currentTemplate: string,
+  outputTrack: string,
+  conflictMode: ConflictMode = null
+) {
   const filePath = await getTranscriptPath(filename);
   const response = await fetch(resolveAPI, {
     method: 'POST',
@@ -64,6 +96,7 @@ export async function addSubtitlesToTimeline(filename: string, currentTemplate: 
       filePath,
       templateName: currentTemplate,
       trackIndex: outputTrack,
+      conflictMode,
     }),
   });
   return response.json();

--- a/AutoSubs-App/src/components/desktop-subtitle-viewer.tsx
+++ b/AutoSubs-App/src/components/desktop-subtitle-viewer.tsx
@@ -6,9 +6,21 @@ import { useGlobal } from "@/contexts/GlobalContext"
 import { ImportExportPopover } from "@/components/import-export-popover"
 import { SpeakerEditor } from "@/components/speaker-editor"
 import { ReplaceStringsPanel } from "@/components/replace-strings-dialog"
+import { TrackConflictDialog } from "@/components/track-conflict-dialog"
 
 export function DesktopSubtitleViewer() {
-  const { subtitles, exportSubtitlesAs, importSubtitles, pushToTimeline, settings, updateSubtitles } = useGlobal()
+  const { 
+    subtitles, 
+    exportSubtitlesAs, 
+    importSubtitles, 
+    pushToTimeline, 
+    settings, 
+    updateSubtitles,
+    conflictInfo,
+    showConflictDialog,
+    setShowConflictDialog,
+    resolveConflictAndPush,
+  } = useGlobal()
   const [showSpeakerEditor, setShowSpeakerEditor] = React.useState(false)
   const [isPushing, setIsPushing] = React.useState(false)
   const [highlightText, setHighlightText] = React.useState("")
@@ -103,6 +115,21 @@ export function DesktopSubtitleViewer() {
           </Button>
         </div>
       )}
+
+      {/* Track Conflict Resolution Dialog */}
+      <TrackConflictDialog
+        open={showConflictDialog}
+        onOpenChange={setShowConflictDialog}
+        conflictInfo={conflictInfo}
+        onResolve={async (mode) => {
+          setIsPushing(true)
+          try {
+            await resolveConflictAndPush(mode)
+          } finally {
+            setIsPushing(false)
+          }
+        }}
+      />
     </div>
   )
 }

--- a/AutoSubs-App/src/components/mobile-subtitle-viewer.tsx
+++ b/AutoSubs-App/src/components/mobile-subtitle-viewer.tsx
@@ -6,6 +6,7 @@ import { useGlobal } from "@/contexts/GlobalContext"
 import { ImportExportPopover } from "@/components/import-export-popover"
 import { SpeakerEditor } from "@/components/speaker-editor"
 import { ReplaceStringsPanel } from "@/components/replace-strings-dialog"
+import { TrackConflictDialog } from "@/components/track-conflict-dialog"
 
 interface MobileSubtitleViewerProps {
   isOpen: boolean
@@ -13,7 +14,18 @@ interface MobileSubtitleViewerProps {
 }
 
 export function MobileSubtitleViewer({ isOpen, onClose }: MobileSubtitleViewerProps) {
-  const { exportSubtitlesAs, importSubtitles, subtitles, pushToTimeline, settings, updateSubtitles } = useGlobal()
+  const { 
+    exportSubtitlesAs, 
+    importSubtitles, 
+    subtitles, 
+    pushToTimeline, 
+    settings, 
+    updateSubtitles,
+    conflictInfo,
+    showConflictDialog,
+    setShowConflictDialog,
+    resolveConflictAndPush,
+  } = useGlobal()
   const [showSpeakerEditor, setShowSpeakerEditor] = React.useState(false)
   const [isPushing, setIsPushing] = React.useState(false)
   const [highlightText, setHighlightText] = React.useState("")
@@ -142,6 +154,21 @@ export function MobileSubtitleViewer({ isOpen, onClose }: MobileSubtitleViewerPr
         </Button>
       </div>
       )}
+
+      {/* Track Conflict Resolution Dialog */}
+      <TrackConflictDialog
+        open={showConflictDialog}
+        onOpenChange={setShowConflictDialog}
+        conflictInfo={conflictInfo}
+        onResolve={async (mode) => {
+          setIsPushing(true)
+          try {
+            await resolveConflictAndPush(mode)
+          } finally {
+            setIsPushing(false)
+          }
+        }}
+      />
     </div>
   )
 }

--- a/AutoSubs-App/src/components/settings-cards/audio-input-card.tsx
+++ b/AutoSubs-App/src/components/settings-cards/audio-input-card.tsx
@@ -150,7 +150,7 @@ export const AudioInputCard = ({ selectedTracks, onTracksChange, callRefresh, wa
                 </div>
               )}
               {inputTracks.length > 0 ? (
-                <ScrollArea style={{ maxHeight: '200px', width: '100%' }}>
+                <ScrollArea className="h-[200px] w-full">
                   <div className="flex flex-col gap-1 p-2">
                     {inputTracks.map((track) => {
                       const trackId = track.value;

--- a/AutoSubs-App/src/components/settings-cards/audio-input-card.tsx
+++ b/AutoSubs-App/src/components/settings-cards/audio-input-card.tsx
@@ -109,7 +109,7 @@ export const AudioInputCard = ({ selectedTracks, onTracksChange, callRefresh, wa
                 {selectedTracks.length === 0
                   ? "Select tracks..."
                   : selectedTracks.length === 1
-                    ? `Track ${selectedTracks[0]}`
+                    ? inputTracks.find(track => track.value === selectedTracks[0])?.label || `Track ${selectedTracks[0]}`
                     : `${selectedTracks.length} tracks selected`
                 }
                 <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />

--- a/AutoSubs-App/src/components/subtitle-list.tsx
+++ b/AutoSubs-App/src/components/subtitle-list.tsx
@@ -395,7 +395,6 @@ const SubtitleList = ({
                     >
                         {visibleItems.map((subtitle: Subtitle, virtualIndex: number) => {
                             const actualIndex = startIndex + virtualIndex;
-                            const isHighlighted = highlightedSubtitleIndex === actualIndex;
                             const isAnimating = animatingIndex === actualIndex;
                             return (
                                 <div

--- a/AutoSubs-App/src/components/track-conflict-dialog.tsx
+++ b/AutoSubs-App/src/components/track-conflict-dialog.tsx
@@ -1,6 +1,5 @@
 import {
   AlertDialog,
-  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,

--- a/AutoSubs-App/src/components/track-conflict-dialog.tsx
+++ b/AutoSubs-App/src/components/track-conflict-dialog.tsx
@@ -1,0 +1,123 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { ConflictInfo, ConflictMode } from "@/api/resolveAPI";
+import { AlertTriangle, Replace, SkipForward, Plus } from "lucide-react";
+
+interface TrackConflictDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  conflictInfo: ConflictInfo | null;
+  onResolve: (mode: ConflictMode) => void;
+}
+
+function formatTime(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+}
+
+export function TrackConflictDialog({
+  open,
+  onOpenChange,
+  conflictInfo,
+  onResolve,
+}: TrackConflictDialogProps) {
+  if (!conflictInfo) return null;
+
+  const conflictCount = conflictInfo.totalConflicts || 0;
+  const trackName = conflictInfo.trackName || "selected track";
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent className="max-w-md">
+        <AlertDialogHeader>
+          <AlertDialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-amber-500" />
+            Existing Content Detected
+          </AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-3">
+              <p>
+                Found <span className="font-semibold text-foreground">{conflictCount} existing clip{conflictCount !== 1 ? 's' : ''}</span> on{' '}
+                <span className="font-semibold text-foreground">"{trackName}"</span> that overlap with your new subtitles.
+              </p>
+              
+              {conflictInfo.subtitleRange && (
+                <p className="text-sm text-muted-foreground">
+                  Subtitle time range: {formatTime(conflictInfo.subtitleRange.start)} - {formatTime(conflictInfo.subtitleRange.end)}
+                </p>
+              )}
+
+              <p className="pt-2">How would you like to proceed?</p>
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <div className="flex flex-col gap-2 py-2">
+          <Button
+            variant="default"
+            className="w-full justify-start gap-2 bg-orange-600 hover:bg-orange-500"
+            onClick={() => {
+              onResolve('replace');
+              onOpenChange(false);
+            }}
+          >
+            <Replace className="h-4 w-4" />
+            <div className="text-left">
+              <div>Replace All</div>
+              <div className="text-xs font-normal opacity-80">Delete existing clips and add new subtitles</div>
+            </div>
+          </Button>
+
+          <Button
+            variant="outline"
+            className="w-full justify-start gap-2"
+            onClick={() => {
+              onResolve('skip');
+              onOpenChange(false);
+            }}
+          >
+            <SkipForward className="h-4 w-4" />
+            <div className="text-left">
+              <div>Skip Conflicts</div>
+              <div className="text-xs font-normal opacity-70">Only add subtitles where there's no existing content</div>
+            </div>
+          </Button>
+
+          <Button
+            variant="outline"
+            className="w-full justify-start gap-2"
+            onClick={() => {
+              onResolve('new_track');
+              onOpenChange(false);
+            }}
+          >
+            <Plus className="h-4 w-4" />
+            <div className="text-left">
+              <div>Use New Track</div>
+              <div className="text-xs font-normal opacity-70">Create a new track for these subtitles</div>
+            </div>
+          </Button>
+        </div>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel asChild>
+            <Button variant="ghost" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+          </AlertDialogCancel>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+

--- a/AutoSubs-App/src/contexts/GlobalContext.tsx
+++ b/AutoSubs-App/src/contexts/GlobalContext.tsx
@@ -418,7 +418,7 @@ export function GlobalProvider({ children }: GlobalProviderProps) {
     isStandaloneMode: boolean,
     fileInput: string | null,
     inputTracks: string[]
-  ): Promise<{ path: string, offset: number } | null> => {
+  ): Promise<{ path: string, offset: number, segments?: Array<{ start: number, end: number, timelineStart: number }> } | null> => {
     if (timelineInfo && !isStandaloneMode) {
       // Reset cancellation flag at the start of export
       cancelRequestedRef.current = false;
@@ -481,9 +481,9 @@ export function GlobalProvider({ children }: GlobalProviderProps) {
         setIsExporting(false);
         setExportProgress(100);
 
-        let audioPath = audioInfo["path"];
-        let audioOffset = audioInfo["offset"];
-        let audioSegments = audioInfo["segments"];
+        const audioPath = audioInfo["path"] as string;
+        const audioOffset = audioInfo["offset"] as number;
+        const audioSegments = audioInfo["segments"] as Array<{ start: number, end: number, timelineStart: number }> | undefined;
         return { path: audioPath, offset: audioOffset, segments: audioSegments };
 
       } catch (error) {

--- a/AutoSubs-App/src/types/interfaces.ts
+++ b/AutoSubs-App/src/types/interfaces.ts
@@ -5,11 +5,20 @@ export interface ErrorMsg {
 }
 
 // Resolve Interfaces
+export interface AudioSegment {
+    start: number;      // Start time within exported audio (seconds)
+    end: number;        // End time within exported audio (seconds)
+    timelineStart: number;  // Absolute start on timeline (seconds)
+    timelineEnd: number;    // Absolute end on timeline (seconds)
+    name: string;       // Clip name
+}
+
 export interface AudioInfo {
     path: string;
     markIn: number;
     markOut: number;
     offset: number;
+    segments?: AudioSegment[];  // Individual clip segments for segment-based transcription
 }
 
 export interface Template {
@@ -115,6 +124,12 @@ export interface Settings {
     highlightColor: string;
 }
 
+export interface TranscriptionSegment {
+    start: number;          // Start time within audio file (seconds)
+    end: number;            // End time within audio file (seconds)  
+    timelineOffset: number; // Offset to add for timeline placement (seconds)
+}
+
 export interface TranscriptionOptions {
     audioPath: string,
     offset: number,
@@ -125,4 +140,5 @@ export interface TranscriptionOptions {
     enableGpu: boolean,
     enableDiarize: boolean,
     maxSpeakers: number | null,
+    segments?: TranscriptionSegment[],  // If provided, only transcribe these segments
 }


### PR DESCRIPTION
## Summary
This PR fixes the Audio Input dropdown scrolling issue and adds several improvements for multi-clip transcription workflows.

## Changes

### Bug Fixes
- **Audio Input scrolling** - Fixed dropdown not scrolling when many audio tracks exist
- **Track name display** - Show actual track name (e.g., "Intro Audio") instead of "Track 1" when single track selected
- **Output track selection** - Subtitles now correctly write to user-selected track instead of creating new one

### New Features
- **Clip boundary detection** - Only exports relevant audio portions based on actual clip locations (no more silent gaps)
- **Multi-clip transcription** - Each clip transcribed independently for accurate timing when multiple clips have gaps between them
- **Track conflict resolution** - Dialog to choose: Replace existing, Skip conflicts, or Use new track

## Technical Details
- Refactored Rust transcription to process clips separately instead of concatenating with silence padding
- Added `GetIndividualClips()` and `GetClipBoundaries()` in Lua for detecting clip ranges
- Added `CheckTrackConflicts()` for conflict detection before subtitle placement

## Testing
Tested with DaVinci Resolve on macOS with multiple audio tracks and clips with gaps.