### PR TITLE
Native support for Fedora via RPM Package

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -307,7 +307,7 @@ jobs:
             libvulkan-dev \
             mesa-vulkan-drivers \
             unzip\
-            rpm-build
+            rpm
           # optional:
           #  vulkan-validationlayers
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,5 +1,7 @@
 name: Package AutoSubs for MacOS and Linux
 on:
+  push:
+    branches: [rpm-support]   # your working branch
   release:
     types: [released]
   workflow_dispatch:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,7 +1,5 @@
 name: Package AutoSubs for MacOS and Linux
 on:
-  push:
-    branches: [rpm-support]   # your working branch
   release:
     types: [released]
   workflow_dispatch:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -114,7 +114,7 @@ jobs:
 
     - name: Download ffmpeg/ffprobe binaries
       env:
-        GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        GH_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
         cd AutoSubs-App/src-tauri
@@ -313,7 +313,7 @@ jobs:
 
       - name: Download ffmpeg/ffprobe binaries (Linux)
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           cd AutoSubs-App/src-tauri

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -259,7 +259,7 @@ jobs:
         tag_name: ${{ env.TAG }}
 
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout AutoSubs Repo Code
         uses: actions/checkout@v4
@@ -304,7 +304,8 @@ jobs:
             pkg-config \
             libvulkan-dev \
             mesa-vulkan-drivers \
-            unzip
+            unzip\
+            rpm-build
           # optional:
           #  vulkan-validationlayers
 
@@ -343,10 +344,11 @@ jobs:
           # Disable default features (mac-specific) for Linux build
           npm run tauri build -- -- --no-default-features --features linux
 
-      - name: Collect Linux artifacts (.deb only)
+      - name: Collect and rename Linux artifacts
         run: |
           set -euo pipefail
           LINUX_BUNDLE_DIR="AutoSubs-App/src-tauri/target/release/bundle"
+          
           # Debian package lives under bundle/deb
           DEB_FILE=$(ls -1 "$LINUX_BUNDLE_DIR/deb"/*.deb 2>/dev/null | head -n1 || true)
           OUT_NAME="AutoSubs-linux-x86_64.deb"
@@ -356,11 +358,21 @@ jobs:
             echo "WARNING: .deb package not found in $LINUX_BUNDLE_DIR/deb"
           fi
 
-      - name: Upload Linux artifacts to Release (.deb only)
+          # RPM package
+          RPM_FILE=$(ls -1 "$LINUX_BUNDLE_DIR/rpm"/*.rpm 2>/dev/null | head -n1 || true)
+          OUT_NAME="AutoSubs-linux-x86_64.rpm"
+          if [ -n "$RPM_FILE" ]; then
+            cp "$RPM_FILE" "$OUT_NAME"
+          else
+            echo "WARNING: .rpm package not found in $LINUX_BUNDLE_DIR/rpm"
+          fi
+
+      - name: Upload Linux artifacts to Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
             *.deb
+            *.rpm
           token: ${{ secrets.GH_TOKEN }}
           tag_name: ${{ env.TAG }}
 

--- a/AutoSubs-App/src-tauri/Cargo.toml
+++ b/AutoSubs-App/src-tauri/Cargo.toml
@@ -44,7 +44,7 @@ tokio = { version = "1", features = ["full"] }
 tauri-plugin-os = "2"
 
 # Transcription engine
-transcription-engine = { path = "crates/transcription-engine" }
+transcription-engine = { path = "crates/transcription-engine", default-features = false }
 
 # Core utilities
 eyre = "0.6"

--- a/AutoSubs-App/src-tauri/linux/autosubs.desktop
+++ b/AutoSubs-App/src-tauri/linux/autosubs.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Categories=AudioVideo;Video;
+Comment=Instantly generate AI-powered subtitles
+Exec=env WEBKIT_DISABLE_DMABUF_RENDERER=1 /usr/bin/autosubs %u
+Icon=autosubs
+Name=AutoSubs
+Terminal=false
+Type=Application

--- a/AutoSubs-App/src-tauri/tauri.conf.json
+++ b/AutoSubs-App/src-tauri/tauri.conf.json
@@ -43,7 +43,8 @@
     "targets": [
       "nsis",
       "app",
-      "deb"
+      "deb",
+      "rpm"
     ],
     "icon": [
       "icons/32x32.png",
@@ -67,6 +68,20 @@
           "/opt/resolve/Fusion/Scripts/Utility/AutoSubs.lua": "resources/AutoSubs.lua",
           "/opt/resolve/Fusion/Scripts/Utility/AutoSubs": "resources/AutoSubs/"
         }
+      },
+      "rpm":{
+        "epoch": 0,
+        "files": {
+          "/opt/resolve/Fusion/Scripts/Utility/AutoSubs.lua": "resources/AutoSubs.lua",
+          "/opt/resolve/Fusion/Scripts/Utility/AutoSubs": "resources/AutoSubs/"
+        },
+        "release": "1",
+        "depends": [
+          "webkit2gtk4.1",
+          "openssl",
+          "libappindicator-gtk3",
+          "librsvg2"
+        ]
       }
     },
     "windows": {

--- a/AutoSubs-App/src-tauri/tauri.conf.json
+++ b/AutoSubs-App/src-tauri/tauri.conf.json
@@ -61,6 +61,7 @@
     },
     "linux": {
       "deb": {
+        "desktopTemplate": "./linux/autosubs.desktop",
         "files": {
           "/opt/resolve/Fusion/Scripts/Utility/AutoSubs.lua": "resources/AutoSubs.lua",
           "/opt/resolve/Fusion/Scripts/Utility/AutoSubs": "resources/AutoSubs/"
@@ -70,6 +71,7 @@
         ]
       },
       "rpm":{
+        "desktopTemplate": "./linux/autosubs.desktop",
         "epoch": 0,
         "files": {
           "/opt/resolve/Fusion/Scripts/Utility/AutoSubs.lua": "resources/AutoSubs.lua",

--- a/AutoSubs-App/src-tauri/tauri.conf.json
+++ b/AutoSubs-App/src-tauri/tauri.conf.json
@@ -56,9 +56,6 @@
     "resources": [
       "resources/"
     ],
-    "externalBin": [
-      "binaries/ffmpeg"
-    ],
     "macOS": {
       "minimumSystemVersion": "13.3"
     },
@@ -67,7 +64,10 @@
         "files": {
           "/opt/resolve/Fusion/Scripts/Utility/AutoSubs.lua": "resources/AutoSubs.lua",
           "/opt/resolve/Fusion/Scripts/Utility/AutoSubs": "resources/AutoSubs/"
-        }
+        },
+        "depends": [
+          "ffmpeg"
+        ]
       },
       "rpm":{
         "epoch": 0,
@@ -80,7 +80,8 @@
           "webkit2gtk4.1",
           "openssl",
           "libappindicator-gtk3",
-          "librsvg2"
+          "librsvg2",
+          "ffmpeg"
         ]
       }
     },

--- a/AutoSubs-App/src-tauri/tauri.macos.conf.json
+++ b/AutoSubs-App/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,7 @@
+{
+  "bundle": {
+    "externalBin": [
+      "binaries/ffmpeg"
+    ]
+  }
+}

--- a/AutoSubs-App/src-tauri/tauri.windows.conf.json
+++ b/AutoSubs-App/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,7 @@
+{
+  "bundle": {
+    "externalBin": [
+      "binaries/ffmpeg"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

This PR removes the ffmpeg sidecar from linux package leveraging dependencies and allows the creation of RPM package via the existing `package.yml` GitHub Action.  
Closes #321

## Key Changes

* RPM configuration added to `tauri.conf.json`.
* `package.yml` creates RPM package for Fedora based distributions.
* Solved bug that broke compilation for non Mac OS in `cargo.toml`.
* Created desktop template for Linux systems.