### PR TITLE
fix: Audio Track Selection Scroll

### DIFF
--- a/AutoSubs-App/src/components/settings/track-selector.tsx
+++ b/AutoSubs-App/src/components/settings/track-selector.tsx
@@ -52,7 +52,7 @@ export function TrackSelector({ inputTracks }: TrackSelectorProps) {
                 </div>
             )}
             {inputTracks.length > 0 ? (
-                <ScrollArea style={{ maxHeight: '200px', width: '100%' }}>
+                <ScrollArea className="max-h-[200px] w-full h-64">
                     <div className="flex flex-col gap-1 p-2">
                         {inputTracks.map((track) => {
                             const trackId = track.value;


### PR DESCRIPTION
Closes #349  
Audio Track Selection is now scrollable 
<img width="471" height="367" alt="image" src="https://github.com/user-attachments/assets/71cedfe0-36fe-4836-b5b4-56347fe72918" />
