### PR TITLE
fix: improve Korean and multi-byte UTF-8 transcription quality

### DIFF
--- a/AutoSubs-App/src-tauri/crates/transcription-engine/src/engines/whisper.rs
+++ b/AutoSubs-App/src-tauri/crates/transcription-engine/src/engines/whisper.rs
@@ -226,33 +226,81 @@ fn get_token_timestamps(seg: &WhisperSegment) -> Vec<WordTimestamp> {
     let n = seg.n_tokens() as usize;
     let mut toks: Vec<Tok> = Vec::with_capacity(n);
 
+    // Whisper's BPE tokenizer routinely splits a single multi-byte UTF-8
+    // codepoint (Hangul, CJK, emoji, …) across multiple consecutive tokens.
+    // Decoding each token in isolation would replace partial byte sequences
+    // with U+FFFD, so we accumulate bytes and only decode at codepoint
+    // boundaries — mirroring how whisper.cpp produces segment-level text.
+    let mut pending: Vec<u8> = Vec::new();
+    let mut pend_t0: Option<f64> = None;
+    let mut pend_t1: f64 = 0.0;
+    let mut pend_anchor: Option<f64> = None;
+    let mut pend_probs: Vec<f32> = Vec::new();
+
     for i in 0..n {
-        if let Some(tok) = seg.get_token(i as i32) {
-            let raw = tok.to_str_lossy().map(|c| c.into_owned()).unwrap_or_default();
+        let Some(tok) = seg.get_token(i as i32) else { continue };
+        let Ok(raw_bytes) = tok.to_bytes() else { continue };
 
-            // Skip whole control tokens like "[_BEG_]" or "[_TT_320]"
-            if is_whole_control_token(&raw) {
-                continue;
+        // Defensive: trim any trailing NULs.
+        let mut end = raw_bytes.len();
+        while end > 0 && raw_bytes[end - 1] == 0 { end -= 1; }
+        let bytes = &raw_bytes[..end];
+        if bytes.is_empty() { continue; }
+
+        // Whole control markers like "[_BEG_]" / "[_TT_320]" are pure ASCII;
+        // detect on raw bytes and skip without touching the pending buffer.
+        if let Ok(s) = std::str::from_utf8(bytes) {
+            if is_whole_control_token(s) { continue; }
+        }
+
+        let td = tok.token_data();
+        let anchor = if td.t_dtw >= 0 { Some(cs_to_s(td.t_dtw)) } else { None };
+        let t0 = cs_to_s(td.t0);
+        let t1 = cs_to_s(td.t1);
+
+        if pending.is_empty() { pend_t0 = Some(t0); }
+        pending.extend_from_slice(bytes);
+        pend_t1 = t1;
+        if anchor.is_some() { pend_anchor = anchor; }
+        pend_probs.push(td.p);
+
+        // If the buffer now ends on a complete codepoint, flush it.
+        if let Ok(decoded) = std::str::from_utf8(&pending) {
+            let clean = strip_embedded_control_markers(decoded);
+            if !clean.trim_matches('\0').trim().is_empty() {
+                let mean_p = pend_probs.iter().sum::<f32>() / pend_probs.len() as f32;
+                toks.push(Tok {
+                    text: clean,
+                    p: mean_p,
+                    t0: pend_t0.unwrap_or(t0),
+                    t1: pend_t1,
+                    anchor: pend_anchor,
+                });
             }
+            pending.clear();
+            pend_t0 = None;
+            pend_anchor = None;
+            pend_probs.clear();
+        }
+    }
 
-            // Remove embedded control markers that hitchhike inside printable tokens
-            let clean = strip_embedded_control_markers(&raw);
-
-            // Skip if nothing printable remains
-            if clean.trim_matches('\0').trim().is_empty() {
-                continue;
-            }
-
-            let td = tok.token_data();
-            // Use DTW anchor only if present (>= 0). Whisper uses -1 when DTW is not computed.
-            let anchor = if td.t_dtw >= 0 { Some(cs_to_s(td.t_dtw)) } else { None };
-
+    // Tail: if anything is left mid-codepoint at the end of the segment,
+    // decode lossily so we don't silently drop characters.
+    if !pending.is_empty() {
+        let decoded = String::from_utf8_lossy(&pending).into_owned();
+        let clean = strip_embedded_control_markers(&decoded);
+        if !clean.trim_matches('\0').trim().is_empty() {
+            let mean_p = if pend_probs.is_empty() {
+                0.0
+            } else {
+                pend_probs.iter().sum::<f32>() / pend_probs.len() as f32
+            };
             toks.push(Tok {
                 text: clean,
-                p: td.p,
-                t0: cs_to_s(td.t0),
-                t1: cs_to_s(td.t1),
-                anchor,
+                p: mean_p,
+                t0: pend_t0.unwrap_or(0.0),
+                t1: pend_t1,
+                anchor: pend_anchor,
             });
         }
     }

--- a/AutoSubs-App/src-tauri/crates/transcription-engine/src/formatting.rs
+++ b/AutoSubs-App/src-tauri/crates/transcription-engine/src/formatting.rs
@@ -37,7 +37,17 @@ struct Tok {
     pub prob: Option<f32>,
     pub speaker: Option<String>,
     pub leading_space: bool, // whether original token text began with a space/newline
+    /// True if this token is the first word of a new whisper segment that was
+    /// preceded by a meaningful pause. Used to force line + cue breaks so the
+    /// formatter respects whisper's natural utterance boundaries instead of
+    /// re-merging short utterances across silence gaps.
+    pub segment_break: bool,
 }
+
+/// Minimum inter-segment silence (seconds) for a whisper segment boundary to
+/// be promoted to a forced cue break. Below this we assume whisper sub-split
+/// the same phrase rather than detecting a real pause.
+const SEGMENT_BREAK_GAP_SEC: f64 = 0.3;
 
 #[inline]
 fn round3(x: f64) -> f64 { (x * 1000.0).round() / 1000.0 }
@@ -248,20 +258,32 @@ pub fn process_segments(
     cfg: &PostProcessConfig,
 ) -> Vec<Segment> {
     // 1) Collect words from all segments, keep speaker_id continuity.
-    let mut all: Vec<(Option<String>, WordTimestamp)> = Vec::new();
-    for seg in segments {
+    //    Mark the first word of each non-first segment with `segment_break`
+    //    when the gap from the previous word's end is large enough to be a
+    //    real utterance boundary (vs. whisper sub-splitting one phrase).
+    let mut all: Vec<(Option<String>, WordTimestamp, bool)> = Vec::new();
+    let mut prev_end: Option<f64> = None;
+    for (seg_idx, seg) in segments.iter().enumerate() {
         let speaker = seg.speaker_id.clone();
-        if let Some(ws) = &seg.words {
-            for w in ws {
-                all.push((speaker.clone(), w.clone()));
+        let words: Vec<WordTimestamp> = match &seg.words {
+            Some(ws) if !ws.is_empty() => ws.clone(),
+            _ => {
+                if !seg.text.trim().is_empty() {
+                    vec![WordTimestamp {
+                        text: seg.text.clone(), start: seg.start, end: seg.end, probability: None,
+                    }]
+                } else {
+                    Vec::new()
+                }
             }
-        } else {
-            // fallback: treat the whole segment as one word if needed
-            if !seg.text.trim().is_empty() {
-                all.push((speaker.clone(), WordTimestamp {
-                    text: seg.text.clone(), start: seg.start, end: seg.end, probability: None,
-                }));
-            }
+        };
+        for (w_idx, w) in words.into_iter().enumerate() {
+            let is_first_in_seg = w_idx == 0;
+            let segment_break = is_first_in_seg
+                && seg_idx > 0
+                && prev_end.map(|pe| (w.start - pe) >= SEGMENT_BREAK_GAP_SEC).unwrap_or(false);
+            prev_end = Some(w.end);
+            all.push((speaker.clone(), w, segment_break));
         }
     }
     if all.is_empty() { return Vec::new(); }
@@ -269,7 +291,7 @@ pub fn process_segments(
     // 2) Normalize tokens: separate trailing punctuation for split logic.
 
     let mut toks: Vec<Tok> = Vec::with_capacity(all.len());
-    for (speaker, w) in all.into_iter() {
+    for (speaker, w, segment_break) in all.into_iter() {
         let (core_raw, punc_raw) = split_trailing_punct(&w.text);
         // Capture whether this token originally had a leading space/newline indicator
         let leading_space = core_raw.starts_with(' ') || core_raw.starts_with('\n');
@@ -288,6 +310,7 @@ pub fn process_segments(
             prob: w.probability,
             speaker,
             leading_space,
+            segment_break,
         });
     }
 
@@ -456,12 +479,17 @@ fn merge_continuations(toks: &mut Vec<Tok>) {
     let mut out: Vec<Tok> = Vec::with_capacity(toks.len());
     for t in std::mem::take(toks).into_iter() {
         if let Some(prev) = out.last_mut() {
-            // Case 1: punctuation-only token -> merge into previous token
+            // Never merge across a forced segment boundary.
+            if t.segment_break {
+                out.push(t);
+                continue;
+            }
+            // Case 1: punctuation-only token -> append its punc to previous's
+            // punc field rather than absorbing prev.punc into the word body.
+            // This preserves terminal markers like "." when followed by a
+            // closing quote/bracket (e.g. `같아요.` + `"` -> punc=`."`).
             if t.word.is_empty() && !t.punc.is_empty() {
-                // Append punctuation to previous without adding space
-                let merged = join_tokens(prev, &t, /*insert_space*/ false);
-                prev.word = merged.0;
-                prev.punc = merged.1;
+                prev.punc.push_str(&t.punc);
                 prev.end = prev.end.max(t.end);
                 continue;
             }
@@ -499,7 +527,10 @@ fn split_trailing_punct(s: &str) -> (&str, &str) {
 }
 
 fn is_terminal_punct(p: &str) -> bool {
-    matches!(p, "." | "!" | "?" | "…" | "。" | "！" | "？")
+    // Match if any character in the punc string is a sentence terminator.
+    // Looser than equality so combos like `."`, `?)`, `…"` still trigger
+    // line breaks when a closing quote/bracket trails the terminator.
+    p.chars().any(|c| matches!(c, '.' | '!' | '?' | '…' | '。' | '！' | '？'))
 }
 
 fn is_comma_like(p: &str) -> bool { matches!(p, "," | "，" | "、" | ";") }
@@ -527,12 +558,15 @@ fn clamp_and_merge_tiny_words(toks: &mut Vec<Tok>, cfg: &PostProcessConfig) {
         }
     }
 
-    // Second pass: merge very tiny words with neighbors (prefer next)
+    // Third pass: merge very tiny words with neighbors (prefer next).
+    // Never merge across a forced segment boundary in either direction.
     let mut out: Vec<Tok> = Vec::with_capacity(toks.len());
     let mut i = 0;
     while i < toks.len() {
         let dur = toks[i].end - toks[i].start;
-        if dur < cfg.min_word_dur && i + 1 < toks.len() {
+        let can_merge_forward = i + 1 < toks.len() && !toks[i + 1].segment_break;
+        let can_merge_back = i > 0 && !toks[i].segment_break;
+        if dur < cfg.min_word_dur && can_merge_forward {
             // merge i into i+1
             let mut next = toks[i + 1].clone();
             let merged_word = join_tokens(&toks[i], &next, cfg.insert_interword_space);
@@ -540,9 +574,11 @@ fn clamp_and_merge_tiny_words(toks: &mut Vec<Tok>, cfg: &PostProcessConfig) {
             next.punc = merged_word.1;
             next.start = toks[i].start.min(next.start);
             next.leading_space = merged_word.2;
+            // Preserve the boundary marker if the absorbed token carried it.
+            next.segment_break = next.segment_break || toks[i].segment_break;
             out.push(next);
             i += 2;
-        } else if dur < cfg.min_word_dur && i > 0 {
+        } else if dur < cfg.min_word_dur && can_merge_back {
             // merge into previous
             let mut prev = out.pop().unwrap();
             let merged_word = join_tokens(&prev, &toks[i], cfg.insert_interword_space);
@@ -673,6 +709,14 @@ fn wrap_into_lines(toks: &[Tok], cfg: &PostProcessConfig) -> Vec<Vec<Tok>> {
                 lines.push(std::mem::take(&mut cur));
                 cur_chars = 0;
             }
+        }
+
+        // Force line break at a whisper segment boundary with a real pause.
+        // This preserves natural utterance boundaries even for short cues
+        // that wouldn't trip the proactive line-fill threshold below.
+        if !cur.is_empty() && tok.segment_break {
+            lines.push(std::mem::take(&mut cur));
+            cur_chars = 0;
         }
 
         // Force line break after terminal punctuation on previous token
@@ -854,6 +898,10 @@ fn group_lines_into_cues(lines: Vec<Vec<Tok>>, cfg: &PostProcessConfig) -> Vec<S
             // Don't mix speakers in one cue
             let next_speaker = lines[j].first().and_then(|t| t.speaker.clone());
             if next_speaker != cue_speaker {
+                break;
+            }
+            // A whisper segment boundary forces a fresh cue, not just a new line
+            if lines[j].first().map(|t| t.segment_break).unwrap_or(false) {
                 break;
             }
             cue_lines.push(&lines[j]);
@@ -1415,9 +1463,9 @@ mod tests {
 
         // Verify adjust_kinsoku shifts the break point
         let toks = vec![
-            Tok { word: "テスト".into(), punc: "".into(), start: 0.0, end: 0.5, prob: None, speaker: None, leading_space: false },
-            Tok { word: "ー".into(), punc: "".into(), start: 0.5, end: 0.6, prob: None, speaker: None, leading_space: false },
-            Tok { word: "データ".into(), punc: "".into(), start: 0.6, end: 1.0, prob: None, speaker: None, leading_space: false },
+            Tok { word: "テスト".into(), punc: "".into(), start: 0.0, end: 0.5, prob: None, speaker: None, leading_space: false, segment_break: false },
+            Tok { word: "ー".into(), punc: "".into(), start: 0.5, end: 0.6, prob: None, speaker: None, leading_space: false, segment_break: false },
+            Tok { word: "データ".into(), punc: "".into(), start: 0.6, end: 1.0, prob: None, speaker: None, leading_space: false, segment_break: false },
         ];
         // Breaking at index 1 would put 'ー' at line start — kinsoku should shift to 2
         let adjusted = adjust_kinsoku(&toks, 1);


### PR DESCRIPTION
Two related issues caused Korean output to be both visually corrupted and poorly cued.

1. **Per-token UTF-8 corruption in whisper.rs** Whisper's BPE tokenizer routinely splits a single Hangul / CJK / emoji codepoint across consecutive tokens, each carrying partial UTF-8 bytes. `get_token_timestamps` was decoding each token in isolation with `to_str_lossy`, replacing every partial sequence with U+FFFD and dropping characters from the per-word output (e.g. 안녕하세요 -> 안 하세요), even though the segment-level text was correct.

Switched to byte accumulation across tokens via `WhisperToken::to_bytes`, decoding only at codepoint boundaries (the same pattern whisper.cpp uses for segment text). Control markers like `[_BEG_]` are still detected on raw ASCII bytes, embedded markers are stripped post-decode, and a `from_utf8_lossy` tail fallback ensures nothing is dropped at segment end. ASCII paths are unchanged.

2. **Over-aggressive cue merging in formatting.rs** `process_segments` flattens whisper segments into a flat word list, discarding the natural utterance boundaries whisper already produced. The post-hoc reconstruction missed real pauses because the proactive line break gate required `cur_chars >= 65% of CPL` before any pause / comma signal could fire — so short Korean utterances (~5 chars) glued onto the next utterance across clear 0.6s+ silences. Even if a line break did fire, `group_lines_into_cues` still packed up to `max_lines` same-speaker lines into one cue.

Added `segment_break` to the internal `Tok`, set on the first word of each non-first segment whose inter-segment gap is >= 0.3s. Honored as a forced line break in `wrap_into_lines` and a forced cue break in `group_lines_into_cues`. `merge_continuations` and `clamp_and_merge_tiny_words` refuse to merge across `segment_break`.

Also fixed an adjacent bug where `같아요` + `.` + `"` was collapsing into `word="같아요.", punc="\""`, hiding the terminator from `is_terminal_punct`. `merge_continuations` now appends punct-only tokens directly to `prev.punc`, and `is_terminal_punct` matches if any character in the punc string is a sentence terminator (handles `."`, `?)`, `…"` etc).

All 16 existing formatting tests still pass.

Closes #378