### PR TITLE
"Adjust Word Timing" compatibility with free version

### DIFF
--- a/Resolve Scripting/AutoSubs-Macro.setting
+++ b/Resolve Scripting/AutoSubs-Macro.setting
@@ -556,7 +556,7 @@
 					-- Find the timeline item that contains this Fusion composition
 					-- Note: DaVinci Resolve has no direct API to get timeline item from comp, so we search manually
 					return function(comp)
-						local resolve = bmd and bmd.scriptapp and bmd.scriptapp("Resolve")
+						local resolve = app:GetResolve()
 						local projectManager = resolve:GetProjectManager()
 						local currentProject = projectManager:GetCurrentProject()
 						local timeline = currentProject:GetCurrentTimeline()


### PR DESCRIPTION
As per #442.  

`bmd.scriptapp("Resolve")` will only work in Studio, not in Free, where scripts can only run internally.  

Replacing with `app:GetResolve()` fixed the issue for me and I was able to use the Adjust Word Timing button.  

(I struggled to figure out how to _use_ `AutoSubs-Macro.setting` in a dev environment though, as I can't seem to clock where that gets _into_ Resolve in the installed AutoSubs either. To confirm @porubma's [suggestion](https://github.com/tmoroney/auto-subs/issues/442#issuecomment-4380362696) addressed the issue, I fed my modified .setting file to the right-click `Settings` -> `Load...` on an AutoSubs node on the Fusion page.  Not sure how it's supposed to be done... I know the whole feature is only like a month old, so the documentation probably just needs an update. 😅)