### PR TITLE
Docs/add homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ AutoSubs generates accurate, timestamped subtitles from any audio or video file.
 Download the installer for your platform above and follow the prompts.
 
 > [!TIP]
->macOS users can also install AutoSubs with Homebrew:
+> macOS users can also install AutoSubs with Homebrew:
 > ```bash
->brew install --cask auto-subs
->```
+> brew install --cask auto-subs
+> ```
 
 ### Linux install
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ AutoSubs generates accurate, timestamped subtitles from any audio or video file.
 
 Download the installer for your platform above and follow the prompts.
 
+> [!TIP]
+>macOS users can also install AutoSubs with Homebrew:
+> ```bash
+>brew install --cask auto-subs
+>```
+
 ### Linux install
 
 **Debian/Ubuntu (.deb):**


### PR DESCRIPTION
## Summary

Adds Homebrew cask installation instructions for macOS users.

```bash
brew install --cask auto-subs
````

## Testing

Docs-only change; no app tests were run.

## Related Issue

https://github.com/Homebrew/homebrew-cask/pull/266845
