### PR TITLE
Add headless CLI for transcription

### DIFF
--- a/AutoSubs-App/README.md
+++ b/AutoSubs-App/README.md
@@ -101,6 +101,74 @@ AI transcription models are downloaded to the app's cache directory. The locatio
 
 The cache directory is automatically created on first model download. Models can be managed through the app's model selection UI.
 
+## Command Line (headless)
+
+AutoSubs can run from the terminal without opening a window, so AI agents and
+terminal-heavy users can transcribe files directly. Given a file argument the app
+runs headlessly, prints the result, and exits with a status code (`0` success,
+`1` on a runtime error, `2` on a usage error). With **no** arguments it launches the
+normal desktop interface.
+
+```bash
+# Readable transcript to the console (default format)
+autosubs interview.mp4 --model small
+
+# Speaker diarization (adds "Speaker N:" labels)
+autosubs interview.mp4 --diarize --max-speakers 2 --lang en
+
+# Pick a format explicitly…
+autosubs interview.mp4 -f srt
+autosubs interview.mp4 -f json
+
+# …or let the output file extension decide
+autosubs interview.mp4 -o subs.srt
+autosubs interview.mp4 -o transcript.json
+
+# Full option list / version
+autosubs --help
+autosubs --version
+```
+
+**Output formats** (`-f` / `--format`):
+
+| Format | Contents |
+|---|---|
+| `text` *(default)* | Readable transcript — `[HH:MM:SS] Speaker N: …`, one paragraph per speaker turn (no word-level timings) |
+| `srt` | SubRip subtitles (one short cue per segment) |
+| `vtt` | WebVTT subtitles (one short cue per segment) |
+| `json` | Full structured transcript including word-level timestamps |
+
+If `--format` is omitted, the format is inferred from the `-o` file extension
+(`.srt`, `.vtt`, `.json`, `.txt`), otherwise it defaults to `text`.
+
+**stdout** carries only the rendered output, so `autosubs file.mp4 -f srt > out.srt`
+is clean and pipe-safe. Progress and errors go to **stderr**: in an interactive
+terminal you get a live progress bar with the current stage (downloading model /
+transcribing / diarizing / translating); when stderr is piped or captured, it falls
+back to one line per stage. On failure a `{ "error": "..." }` object is printed to
+stderr and the exit code is non-zero. Models are downloaded automatically on first
+use to the [model cache](#model-cache-location).
+
+> On Windows, release builds attach to the parent console at startup so output is
+> visible. As with any Tauri CLI app, the shell prompt may return before output
+> finishes printing.
+
+### Getting the `autosubs` command on your PATH
+
+The CLI is the same binary as the desktop app, so it needs to be reachable from
+your shell:
+
+- **Linux** — already done. The `.deb`/`.rpm` installs `/usr/bin/autosubs`, which is
+  on `PATH`. Just run `autosubs <file> ...`.
+- **macOS / Windows** — open **Settings → Command line** in the app and click
+  **Install**. This symlinks the command into `/usr/local/bin` (macOS, prompts for
+  your password) or adds the install folder to your user `PATH` (Windows). **Remove**
+  reverses it. The button reports the current state on each platform.
+
+During development the headless binary is at
+`src-tauri/target/debug/autosubs` (run `cargo build` in `src-tauri` first); symlink it
+yourself with `ln -s "$(pwd)/src-tauri/target/debug/autosubs" /usr/local/bin/autosubs`.
+
 ## Getting Started
 
 See the [root README](../README.md) for installation and usage instructions.

--- a/AutoSubs-App/src-tauri/Cargo.lock
+++ b/AutoSubs-App/src-tauri/Cargo.lock
@@ -42,6 +42,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +309,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-cli",
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
@@ -622,6 +673,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,6 +745,12 @@ dependencies = [
  "core-graphics-types",
  "objc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -2534,6 +2618,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3434,6 +3524,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open"
@@ -5439,6 +5535,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-cli"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28e78fb2c09a81546bcd376d34db4bda5769270d00990daa9f0d6e7ac1107e25"
+dependencies = [
+ "clap",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-clipboard-manager"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6514,6 +6625,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/AutoSubs-App/src-tauri/Cargo.toml
+++ b/AutoSubs-App/src-tauri/Cargo.toml
@@ -44,6 +44,7 @@ tauri-plugin-shell = "2"
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-single-instance = "2"
+tauri-plugin-cli = "2"
 
 reqwest = { version = "0.11", features = ["json", "blocking"] }
 

--- a/AutoSubs-App/src-tauri/capabilities/default.json
+++ b/AutoSubs-App/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
   ],
   "permissions": [
     "core:default",
+    "cli:default",
     "updater:default",
     "shell:allow-open",
     "clipboard-manager:allow-write-text",

--- a/AutoSubs-App/src-tauri/src/cli.rs
+++ b/AutoSubs-App/src-tauri/src/cli.rs
@@ -24,6 +24,7 @@ use std::process::Command;
 
 use crate::transcript_types::{Segment, Transcript};
 use crate::transcription_api::{transcribe_audio, FrontendTranscribeOptions};
+use transcription_engine::TextDensity;
 
 /// True when the app was launched with CLI arguments, meaning "run headless,
 /// don't open a window". Checked against raw `argv` *before* the Tauri app is
@@ -101,8 +102,21 @@ async fn run_transcribe<R: Runtime>(app: AppHandle<R>, m: Matches) -> ! {
         None
     };
 
-    let density = arg_str(&m, "density")
-        .and_then(|s| serde_json::from_value(serde_json::Value::String(s)).ok());
+    // Validate --density up front: an unknown value is a usage error rather than
+    // a silent fall back to the default density (which would produce wrapping the
+    // user didn't ask for). The accepted values match `TextDensity`'s serde repr.
+    let density = match arg_str(&m, "density") {
+        Some(s) => match parse_density(&s) {
+            Some(d) => Some(d),
+            None => {
+                eprintln!(
+                    "autosubs: unknown density '{s}' (expected less, standard, more, single, or custom)"
+                );
+                flush_and_exit(2);
+            }
+        },
+        None => None,
+    };
 
     let options = FrontendTranscribeOptions {
         audio_path: input,
@@ -440,6 +454,13 @@ fn arg_flag(m: &Matches, name: &str) -> bool {
 
 fn arg_num<T: std::str::FromStr>(m: &Matches, name: &str) -> Option<T> {
     arg_str(m, name).and_then(|s| s.parse().ok())
+}
+
+/// Parse a `--density` value into `TextDensity`, case-insensitively. Returns
+/// `None` for unrecognized values so the caller can report a usage error.
+fn parse_density(s: &str) -> Option<TextDensity> {
+    let lower = s.trim().to_ascii_lowercase();
+    serde_json::from_value(serde_json::Value::String(lower)).ok()
 }
 
 /// If clap captured `--help`, return the rendered help text it wants printed.

--- a/AutoSubs-App/src-tauri/src/cli.rs
+++ b/AutoSubs-App/src-tauri/src/cli.rs
@@ -1,0 +1,653 @@
+//! Headless command-line interface.
+//!
+//! AutoSubs is a Tauri desktop app, but when it is launched with a subcommand
+//! (currently just `transcribe`) we run without showing the window, do the work,
+//! print the result, and exit. This lets AI agents and terminal users drive the
+//! transcription engine directly.
+//!
+//! The heavy lifting is reused verbatim from the GUI path:
+//! [`crate::transcription_api::transcribe_audio`] already normalizes audio via the
+//! ffmpeg sidecar, downloads the Whisper model if missing, transcribes, optionally
+//! diarizes, formats, and returns a `Transcript`. We only translate CLI args into
+//! its `FrontendTranscribeOptions` and serialize the result as JSON.
+
+use std::io::{IsTerminal, Write};
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tauri::{AppHandle, Listener, Runtime};
+use tauri_plugin_cli::{CliExt, Matches};
+
+#[allow(unused_imports)]
+use std::process::Command;
+
+use crate::transcript_types::{Segment, Transcript};
+use crate::transcription_api::{transcribe_audio, FrontendTranscribeOptions};
+
+/// True when the app was launched with CLI arguments, meaning "run headless,
+/// don't open a window". Checked against raw `argv` *before* the Tauri app is
+/// built so we can skip window creation and GUI-only plugins (single-instance,
+/// updater, Adobe bridge).
+///
+/// Any argument triggers headless mode; a lone macOS `-psn_…` argument (which
+/// Finder passes on some launches) is ignored so a normal GUI launch isn't
+/// hijacked into the CLI.
+pub fn is_headless_invocation() -> bool {
+    std::env::args().skip(1).any(|a| !a.starts_with("-psn_"))
+}
+
+/// On Windows release builds the process has no attached console (the binary is
+/// built with `windows_subsystem = "windows"`), so stdout/stderr go nowhere when
+/// launched from a shell. Re-attach to the parent console so CLI output is visible.
+#[cfg(windows)]
+pub fn attach_console() {
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn AttachConsole(dwProcessId: u32) -> i32;
+    }
+    const ATTACH_PARENT_PROCESS: u32 = 0xFFFF_FFFF;
+    unsafe {
+        AttachConsole(ATTACH_PARENT_PROCESS);
+    }
+}
+
+#[cfg(not(windows))]
+pub fn attach_console() {}
+
+/// Entry point for the headless path, called from `setup()` once the app handle
+/// is available. Reads the parsed CLI matches, runs the requested subcommand, and
+/// exits the process with an appropriate status code. Never returns.
+pub async fn run<R: Runtime>(app: AppHandle<R>) -> ! {
+    let matches = match app.cli().matches() {
+        Ok(m) => m,
+        // A parse error (missing/unknown argument) — clap already produced a
+        // formatted usage message. Print it plainly and exit 2 (the usual code
+        // for CLI usage errors), not as a JSON runtime error.
+        Err(e) => {
+            eprintln!("{e}");
+            flush_and_exit(2);
+        }
+    };
+
+    // `--version`: the plugin signals it via the presence of a "version" arg but
+    // does not provide the string, so print the app version ourselves.
+    if matches.args.contains_key("version") {
+        println!("autosubs {}", app.package_info().version);
+        flush_and_exit(0);
+    }
+
+    // `--help`: the plugin puts the rendered help text in the "help" arg's value.
+    if let Some(text) = help_text(&matches) {
+        println!("{text}");
+        flush_and_exit(0);
+    }
+
+    run_transcribe(app, matches).await
+}
+
+async fn run_transcribe<R: Runtime>(app: AppHandle<R>, m: Matches) -> ! {
+    let input = match arg_str(&m, "input") {
+        Some(p) => p,
+        None => fail("missing required <input> file path"),
+    };
+
+    // GPU: default on (mirrors transcribe_audio's `.or(Some(true))`); --no-gpu wins.
+    let enable_gpu = if arg_flag(&m, "no-gpu") {
+        Some(false)
+    } else if arg_flag(&m, "gpu") {
+        Some(true)
+    } else {
+        None
+    };
+
+    let density = arg_str(&m, "density")
+        .and_then(|s| serde_json::from_value(serde_json::Value::String(s)).ok());
+
+    let options = FrontendTranscribeOptions {
+        audio_path: input,
+        offset: None,
+        model: arg_str(&m, "model").unwrap_or_else(|| "small".to_string()),
+        lang: arg_str(&m, "lang"),
+        translate: Some(arg_flag(&m, "translate")),
+        target_language: arg_str(&m, "target-language"),
+        enable_dtw: None,
+        enable_gpu,
+        enable_diarize: Some(arg_flag(&m, "diarize")),
+        max_speakers: arg_num(&m, "max-speakers"),
+        density,
+        max_lines: arg_num(&m, "max-lines"),
+        custom_max_chars_per_line: arg_num(&m, "max-chars-per-line"),
+        text_case: arg_str(&m, "text-case"),
+        remove_punctuation: Some(arg_flag(&m, "remove-punctuation")),
+        censored_words: None,
+        custom_prompt: arg_str(&m, "prompt"),
+    };
+
+    let output = arg_str(&m, "output");
+
+    // Resolve the output format up front so a bad value fails before doing work.
+    let format = match resolve_format(arg_str(&m, "format").as_deref(), output.as_deref()) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("autosubs: {e}");
+            flush_and_exit(2);
+        }
+    };
+
+    // Progress reporting on stderr. `transcribe_audio` already emits
+    // `labeled-progress` events ({progress, type, label}); we render them as a live
+    // bar on a TTY, or as one line per high-level stage when stderr is piped (so an
+    // agent capturing stderr gets clean, non-spammy output). stdout stays JSON-only.
+    let is_tty = std::io::stderr().is_terminal();
+    eprintln!("autosubs: starting (model={})", options.model);
+
+    let events = app.clone();
+    let last_stage: Arc<std::sync::Mutex<Option<String>>> = Arc::new(std::sync::Mutex::new(None));
+    let last_stage_cb = last_stage.clone();
+    let listener_id = events.listen("labeled-progress", move |event| {
+        let Ok(ev) = serde_json::from_str::<ProgressEvent>(event.payload()) else {
+            return;
+        };
+        let stage = ev.stage.as_deref().unwrap_or("");
+        // Ignore the initial null-stage tick (before the engine sets a real stage).
+        if stage.is_empty() {
+            return;
+        }
+        if is_tty {
+            let mut err = std::io::stderr();
+            let _ = write!(err, "{}", render_bar(stage, ev.progress));
+            let _ = err.flush();
+        } else if let Ok(mut last) = last_stage_cb.lock() {
+            if last.as_deref() != Some(stage) {
+                eprintln!("autosubs: {}...", stage_label(stage).to_lowercase());
+                *last = Some(stage.to_string());
+            }
+        }
+    });
+
+    let result = transcribe_audio(app, options).await;
+
+    events.unlisten(listener_id);
+    if is_tty {
+        // Terminate the in-place bar line so later output isn't overwritten.
+        eprintln!();
+    }
+
+    match result {
+        Ok(transcript) => {
+            let mut rendered = match format {
+                OutputFormat::Json => serde_json::to_string_pretty(&transcript)
+                    .unwrap_or_else(|e| fail(&format!("failed to serialize transcript: {e}"))),
+                OutputFormat::Text => render_text(&transcript),
+                OutputFormat::Srt => render_srt(&transcript),
+                OutputFormat::Vtt => render_vtt(&transcript),
+            };
+            if !rendered.ends_with('\n') {
+                rendered.push('\n');
+            }
+            match output {
+                Some(path) => {
+                    if let Err(e) = std::fs::write(&path, &rendered) {
+                        fail(&format!("failed to write '{path}': {e}"));
+                    }
+                    eprintln!("autosubs: wrote {} to {path}", format.name());
+                }
+                None => print!("{rendered}"),
+            }
+            flush_and_exit(0);
+        }
+        Err(e) => fail(&e),
+    }
+}
+
+// --- output formats ---
+
+#[derive(Clone, Copy)]
+enum OutputFormat {
+    /// Readable transcript: one line per segment, speaker-labelled, no word timings.
+    Text,
+    /// Full structured transcript including word-level timestamps.
+    Json,
+    Srt,
+    Vtt,
+}
+
+impl OutputFormat {
+    fn parse(s: &str) -> Result<Self, String> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "text" | "txt" => Ok(Self::Text),
+            "json" => Ok(Self::Json),
+            "srt" => Ok(Self::Srt),
+            "vtt" | "webvtt" => Ok(Self::Vtt),
+            other => Err(format!(
+                "unknown format '{other}' (expected text, json, srt, or vtt)"
+            )),
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::Text => "transcript",
+            Self::Json => "JSON",
+            Self::Srt => "SRT",
+            Self::Vtt => "VTT",
+        }
+    }
+}
+
+/// Explicit `--format` wins; otherwise infer from the `-o` file extension; else text.
+fn resolve_format(explicit: Option<&str>, output: Option<&str>) -> Result<OutputFormat, String> {
+    if let Some(f) = explicit {
+        return OutputFormat::parse(f);
+    }
+    if let Some(ext) = output
+        .and_then(|p| std::path::Path::new(p).extension())
+        .and_then(|e| e.to_str())
+    {
+        if let Ok(f) = OutputFormat::parse(ext) {
+            return Ok(f);
+        }
+    }
+    Ok(OutputFormat::Text)
+}
+
+/// Speaker label for a segment, e.g. `Speaker 1`. `speaker_id` is the engine's
+/// numeric id ("1", "2", …) or "?" when unknown.
+fn speaker_prefix(seg: &Segment) -> String {
+    seg.speaker_id
+        .as_deref()
+        .map(|id| format!("Speaker {id}: "))
+        .unwrap_or_default()
+}
+
+fn hms(seconds: f64) -> (u64, u64, u64, u64) {
+    let total_ms = (seconds.max(0.0) * 1000.0).round() as u64;
+    (
+        total_ms / 3_600_000,
+        (total_ms / 60_000) % 60,
+        (total_ms / 1000) % 60,
+        total_ms % 1000,
+    )
+}
+
+fn ts_srt(s: f64) -> String {
+    let (h, m, s, ms) = hms(s);
+    format!("{h:02}:{m:02}:{s:02},{ms:03}")
+}
+
+fn ts_vtt(s: f64) -> String {
+    let (h, m, s, ms) = hms(s);
+    format!("{h:02}:{m:02}:{s:02}.{ms:03}")
+}
+
+fn ts_clock(s: f64) -> String {
+    let (h, m, s, _) = hms(s);
+    format!("{h:02}:{m:02}:{s:02}")
+}
+
+/// `[HH:MM:SS] Speaker N: text` per *speaker turn* — the default, human-readable
+/// transcript. The engine's segments are short subtitle cues (wrapped for on-screen
+/// display), which read poorly as prose, so consecutive cues are merged into one
+/// paragraph while the speaker stays the same. When there is no diarization (no
+/// speaker labels), a silence gap longer than `GAP_BREAK_SECS` starts a new
+/// paragraph instead, so the transcript still breaks at natural pauses.
+fn render_text(t: &Transcript) -> String {
+    const GAP_BREAK_SECS: f64 = 2.0;
+
+    let mut out = String::new();
+    let mut start = 0.0;
+    let mut end = 0.0;
+    let mut speaker: Option<String> = None;
+    let mut text = String::new();
+    let mut open = false;
+
+    for seg in &t.segments {
+        let line = seg.text.trim();
+        if line.is_empty() {
+            continue;
+        }
+        // Continue the current paragraph if the speaker matches and either we have
+        // a speaker label (turns are the unit) or the gap since the last cue is small.
+        let continues = open
+            && speaker.as_deref() == seg.speaker_id.as_deref()
+            && (seg.speaker_id.is_some() || seg.start - end <= GAP_BREAK_SECS);
+
+        if continues {
+            if !text.ends_with(' ') {
+                text.push(' ');
+            }
+            text.push_str(line);
+            end = seg.end.max(end);
+        } else {
+            if open {
+                out.push_str(&text_line(start, &speaker, &text));
+            }
+            start = seg.start;
+            end = seg.end;
+            speaker = seg.speaker_id.clone();
+            text = line.to_string();
+            open = true;
+        }
+    }
+    if open {
+        out.push_str(&text_line(start, &speaker, &text));
+    }
+    out
+}
+
+fn text_line(start: f64, speaker: &Option<String>, text: &str) -> String {
+    let prefix = speaker
+        .as_deref()
+        .map(|id| format!("Speaker {id}: "))
+        .unwrap_or_default();
+    format!("[{}] {prefix}{text}\n", ts_clock(start))
+}
+
+fn render_srt(t: &Transcript) -> String {
+    let mut out = String::new();
+    for (i, seg) in t.segments.iter().enumerate() {
+        let end = seg.end.max(seg.start);
+        out.push_str(&format!(
+            "{}\n{} --> {}\n{}{}\n\n",
+            i + 1,
+            ts_srt(seg.start),
+            ts_srt(end),
+            speaker_prefix(seg),
+            seg.text.trim()
+        ));
+    }
+    out
+}
+
+fn render_vtt(t: &Transcript) -> String {
+    let mut out = String::from("WEBVTT\n\n");
+    for seg in &t.segments {
+        let end = seg.end.max(seg.start);
+        out.push_str(&format!(
+            "{} --> {}\n{}{}\n\n",
+            ts_vtt(seg.start),
+            ts_vtt(end),
+            speaker_prefix(seg),
+            seg.text.trim()
+        ));
+    }
+    out
+}
+
+/// Print an error as a JSON object on stderr and exit non-zero. Never returns.
+fn fail(message: &str) -> ! {
+    eprintln!("{}", json!({ "error": message }));
+    flush_and_exit(1);
+}
+
+fn flush_and_exit(code: i32) -> ! {
+    let _ = std::io::stdout().flush();
+    let _ = std::io::stderr().flush();
+    // Bypass Tauri's exit handling: it can override our exit code during its
+    // shutdown cleanup, and there is no GUI/Resolve state to tear down here.
+    std::process::exit(code);
+}
+
+// --- progress rendering ---
+
+/// Subset of the `labeled-progress` event payload emitted by `transcribe_audio`.
+/// The `label` field is intentionally ignored; the stage is derived from `type`.
+#[derive(Deserialize)]
+struct ProgressEvent {
+    progress: i32,
+    #[serde(rename = "type")]
+    stage: Option<String>,
+}
+
+/// Map an engine `ProgressType` (Debug string) to a human stage name.
+fn stage_label(stage: &str) -> &'static str {
+    match stage {
+        "Download" => "Downloading model",
+        "Diarize" => "Diarizing",
+        "Transcribe" => "Transcribing",
+        "Translate" => "Translating",
+        _ => "Processing",
+    }
+}
+
+/// A carriage-return-prefixed progress bar line for in-place TTY updates, e.g.
+/// `Transcribing       [████████░░░░░░░░] 50%`.
+fn render_bar(stage: &str, percent: i32) -> String {
+    const WIDTH: usize = 24;
+    let pct = percent.clamp(0, 100) as usize;
+    let filled = pct * WIDTH / 100;
+    let bar = "█".repeat(filled) + &"░".repeat(WIDTH - filled);
+    // Pad the label and trail a few spaces so the line stays aligned and fully
+    // overwrites the previous (possibly longer) render.
+    format!("\r{:<18} [{}] {:>3}%   ", stage_label(stage), bar, pct)
+}
+
+// --- arg accessors over tauri-plugin-cli's Matches ---
+
+fn arg_str(m: &Matches, name: &str) -> Option<String> {
+    m.args
+        .get(name)
+        .and_then(|a| a.value.as_str().map(|s| s.to_string()))
+}
+
+fn arg_flag(m: &Matches, name: &str) -> bool {
+    m.args
+        .get(name)
+        .map(|a| a.value.as_bool().unwrap_or(false) || a.occurrences > 0)
+        .unwrap_or(false)
+}
+
+fn arg_num<T: std::str::FromStr>(m: &Matches, name: &str) -> Option<T> {
+    arg_str(m, name).and_then(|s| s.parse().ok())
+}
+
+/// If clap captured `--help`, return the rendered help text it wants printed.
+fn help_text(m: &Matches) -> Option<String> {
+    m.args
+        .get("help")
+        .and_then(|arg| arg.value.as_str().map(|s| s.to_string()))
+}
+
+// ---------------------------------------------------------------------------
+// In-app "Install command-line tool" support (VS Code style).
+//
+// Puts an `autosubs` command on the user's PATH so the headless CLI can be run
+// as a bare command from any terminal. Linux packages already install
+// `/usr/bin/autosubs`, so there it is reported as available and managed by the
+// package manager (the in-app action is a no-op).
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+pub struct CliStatus {
+    /// `autosubs` currently resolves on PATH (or the managed symlink exists).
+    installed: bool,
+    /// Whether the in-app Install/Remove action applies on this OS.
+    manageable: bool,
+    /// Where the command is (or would be) installed.
+    location: Option<String>,
+    /// Human-readable platform note (shown when not manageable in-app).
+    note: Option<String>,
+}
+
+#[cfg(target_os = "macos")]
+const MACOS_CLI_LINK: &str = "/usr/local/bin/autosubs";
+
+/// Report whether the `autosubs` command is on the user's PATH and whether the
+/// in-app button can manage it on this platform.
+#[tauri::command]
+pub fn cli_command_status() -> CliStatus {
+    #[cfg(target_os = "macos")]
+    {
+        CliStatus {
+            installed: std::fs::symlink_metadata(MACOS_CLI_LINK).is_ok(),
+            manageable: true,
+            location: Some(MACOS_CLI_LINK.to_string()),
+            note: None,
+        }
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let dir = exe_dir();
+        let installed = dir.as_ref().map(|d| windows_path_contains(d)).unwrap_or(false);
+        CliStatus {
+            installed,
+            manageable: true,
+            location: dir.map(|d| d.to_string_lossy().to_string()),
+            note: None,
+        }
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let found = which::which("autosubs").ok();
+        CliStatus {
+            installed: found.is_some(),
+            manageable: false,
+            location: found.map(|p| p.to_string_lossy().to_string()),
+            note: Some(
+                "On Linux the `autosubs` command is installed and managed by your package (deb/rpm)."
+                    .to_string(),
+            ),
+        }
+    }
+}
+
+/// Add `autosubs` to the user's PATH. Returns the refreshed status.
+#[tauri::command]
+pub fn install_cli_command() -> Result<CliStatus, String> {
+    #[cfg(target_os = "macos")]
+    {
+        let exe = current_exe_string()?;
+        run_admin_macos(&format!(
+            "mkdir -p /usr/local/bin && ln -sf '{exe}' '{MACOS_CLI_LINK}'"
+        ))?;
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let dir = exe_dir().ok_or("could not determine the install directory")?;
+        let dir = dir.to_string_lossy().to_string();
+        if !windows_path_contains(std::path::Path::new(&dir)) {
+            windows_set_user_path_append(&dir)?;
+        }
+    }
+    #[cfg(target_os = "linux")]
+    {
+        return Err(
+            "On Linux the `autosubs` command is managed by your package manager.".to_string(),
+        );
+    }
+    Ok(cli_command_status())
+}
+
+/// Remove the `autosubs` command from the user's PATH. Returns refreshed status.
+#[tauri::command]
+pub fn uninstall_cli_command() -> Result<CliStatus, String> {
+    #[cfg(target_os = "macos")]
+    {
+        run_admin_macos(&format!("rm -f '{MACOS_CLI_LINK}'"))?;
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let dir = exe_dir().ok_or("could not determine the install directory")?;
+        windows_remove_user_path(&dir.to_string_lossy())?;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        return Err(
+            "On Linux the `autosubs` command is managed by your package manager.".to_string(),
+        );
+    }
+    Ok(cli_command_status())
+}
+
+#[cfg(target_os = "macos")]
+fn current_exe_string() -> Result<String, String> {
+    std::env::current_exe()
+        .map_err(|e| format!("could not locate the app executable: {e}"))
+        .map(|p| p.to_string_lossy().to_string())
+}
+
+/// Run a shell command with administrator privileges via the native macOS
+/// password prompt (AppleScript). Used because `/usr/local/bin` is root-owned.
+#[cfg(target_os = "macos")]
+fn run_admin_macos(shell_script: &str) -> Result<(), String> {
+    let escaped = shell_script.replace('\\', "\\\\").replace('"', "\\\"");
+    let apple = format!("do shell script \"{escaped}\" with administrator privileges");
+    let out = Command::new("osascript")
+        .arg("-e")
+        .arg(apple)
+        .output()
+        .map_err(|e| format!("failed to run osascript: {e}"))?;
+    if out.status.success() {
+        return Ok(());
+    }
+    let err = String::from_utf8_lossy(&out.stderr);
+    if err.contains("User canceled") || err.contains("-128") {
+        Err("Cancelled.".to_string())
+    } else {
+        Err(format!("Failed to update /usr/local/bin: {}", err.trim()))
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn exe_dir() -> Option<std::path::PathBuf> {
+    std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+}
+
+/// The persistent (registry-backed) user PATH, not the current process PATH.
+#[cfg(target_os = "windows")]
+fn windows_user_path() -> String {
+    match Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-Command",
+            "[Environment]::GetEnvironmentVariable('Path','User')",
+        ])
+        .output()
+    {
+        Ok(o) => String::from_utf8_lossy(&o.stdout).trim().to_string(),
+        Err(_) => String::new(),
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn windows_path_contains(dir: &std::path::Path) -> bool {
+    let needle = dir.to_string_lossy().to_lowercase();
+    let needle = needle.trim_end_matches('\\');
+    windows_user_path()
+        .split(';')
+        .any(|p| p.trim().to_lowercase().trim_end_matches('\\') == needle)
+}
+
+#[cfg(target_os = "windows")]
+fn run_powershell(script: &str) -> Result<(), String> {
+    let out = Command::new("powershell")
+        .args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script])
+        .output()
+        .map_err(|e| format!("failed to run PowerShell: {e}"))?;
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(String::from_utf8_lossy(&out.stderr).trim().to_string())
+    }
+}
+
+/// Append `dir` to the persistent user PATH (setting it broadcasts the change so
+/// newly opened terminals pick it up). User scope needs no administrator rights.
+#[cfg(target_os = "windows")]
+fn windows_set_user_path_append(dir: &str) -> Result<(), String> {
+    let script = format!(
+        "$p=[Environment]::GetEnvironmentVariable('Path','User'); if([string]::IsNullOrEmpty($p)){{$p=''}}; if($p -notlike '*{dir}*'){{ if($p -and -not $p.EndsWith(';')){{$p+=';'}}; $p+='{dir}'; [Environment]::SetEnvironmentVariable('Path',$p,'User') }}"
+    );
+    run_powershell(&script)
+}
+
+#[cfg(target_os = "windows")]
+fn windows_remove_user_path(dir: &str) -> Result<(), String> {
+    let script = format!(
+        "$d='{dir}'.TrimEnd('\\'); $p=[Environment]::GetEnvironmentVariable('Path','User'); if($p){{ $parts=$p.Split(';') | Where-Object {{ $_ -and ($_.TrimEnd('\\') -ne $d) }}; [Environment]::SetEnvironmentVariable('Path', ($parts -join ';'), 'User') }}"
+    );
+    run_powershell(&script)
+}

--- a/AutoSubs-App/src-tauri/src/main.rs
+++ b/AutoSubs-App/src-tauri/src/main.rs
@@ -31,6 +31,7 @@ mod transcript_types;
 mod logging;
 mod resolve_bridge;
 mod adobe_bridge;
+mod cli;
 #[cfg(target_os = "macos")]
 mod traffic_lights;
 
@@ -60,12 +61,57 @@ fn trigger_install_update(state: tauri::State<InstallSignal>) {
     state.0.notify_one();
 }
 
+/// Build the main GUI window programmatically.
+///
+/// The window is intentionally NOT declared in `tauri.conf.json`: a config-defined
+/// window is created automatically at startup, which spins up a webview even for a
+/// headless CLI run (adding startup cost, a dock/taskbar flash, and a needless
+/// WebView/WebKitGTK dependency). Creating it here means it only exists in GUI mode.
+///
+/// Mirrors the previous `tauri.conf.json` window config. It starts hidden and is
+/// shown later (after the macOS traffic-light positioner is installed), matching the
+/// existing startup flow.
+fn create_main_window(app: &tauri::AppHandle) -> tauri::Result<tauri::WebviewWindow> {
+    #[allow(unused_mut)]
+    let mut builder =
+        tauri::WebviewWindowBuilder::new(app, "main", tauri::WebviewUrl::App("index.html".into()))
+            .title("AutoSubs")
+            .inner_size(750.0, 700.0)
+            .decorations(true)
+            .accept_first_mouse(true)
+            .visible(false);
+
+    #[cfg(target_os = "macos")]
+    {
+        builder = builder
+            .title_bar_style(tauri::TitleBarStyle::Overlay)
+            .traffic_light_position(tauri::LogicalPosition::new(16.0_f64, 25.0_f64));
+    }
+
+    // `zoom_hotkeys_enabled` is only available off macOS without the
+    // `macos-private-api` feature; matches the old config's `zoomHotkeysEnabled`.
+    #[cfg(not(target_os = "macos"))]
+    {
+        builder = builder.zoom_hotkeys_enabled(true);
+    }
+
+    builder.build()
+}
+
 fn main() {
     // Route whisper.cpp C-side logs through Rust's tracing system so they can be
     // filtered rather than being dumped raw to stderr.
     transcription_engine::install_logging_hooks();
 
-    tauri::Builder::default()
+    // Decide GUI vs headless from raw argv *before* building, so we can hide the
+    // window and skip GUI-only plugins (single-instance would forward our args to
+    // a running GUI and exit, breaking a CLI run while the app is open).
+    let headless = cli::is_headless_invocation();
+    if headless {
+        cli::attach_console();
+    }
+
+    let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_os::init())
@@ -77,13 +123,38 @@ fn main() {
         .plugin(shell_plugin())
         .plugin(clipboard_plugin())
         .plugin(opener_plugin())
-        .plugin(single_instance_plugin(|app, _args, _cwd| {
+        .plugin(tauri_plugin_cli::init());
+
+    if !headless {
+        builder = builder.plugin(single_instance_plugin(|app, _args, _cwd| {
             // Focus the existing window when a second instance is launched
             let _ = app.get_webview_window("main").map(|w| w.set_focus());
-        }))
-        .setup(|app| {
-            // Initialize backend logging (file + in-memory ring buffer)
+        }));
+    }
+
+    builder
+        .setup(move |app| {
+            // Initialize backend logging (file + in-memory ring buffer). Logs go to
+            // the log file only, never stdout/stderr, so CLI output stays clean.
             crate::logging::init_logging(&app.handle());
+
+            if headless {
+                // Headless/CLI: never create a window. Hide the macOS dock icon so a
+                // CLI run is fully invisible, then run the subcommand and exit.
+                #[cfg(target_os = "macos")]
+                app.set_activation_policy(tauri::ActivationPolicy::Accessory);
+
+                let handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    cli::run(handle).await;
+                });
+                return Ok(());
+            }
+
+            // GUI mode: create the main window programmatically (see create_main_window
+            // for why it isn't declared in tauri.conf.json).
+            create_main_window(app.handle())?;
+
             crate::adobe_bridge::init_adobe_server(app.handle().clone());
 
             // Set window title to "AutoSubs" on Windows and Linux for taskbar display
@@ -288,13 +359,21 @@ fn main() {
             resolve_bridge::resolve_bridge,
             adobe_bridge::send_to_adobe,
             trigger_install_update,
-            audio_preprocess::extract_audio_peaks
+            audio_preprocess::extract_audio_peaks,
+            cli::cli_command_status,
+            cli::install_cli_command,
+            cli::uninstall_cli_command
         ])
         .build(tauri::generate_context!())
         .expect("error while building Tauri application")
-        .run(|app, event| {
+        .run(move |app, event| {
             match event {
                 RunEvent::Ready => {
+                    // Headless runs keep the window hidden; cli::run drives the work
+                    // and exits the process itself.
+                    if headless {
+                        return;
+                    }
                     let app_handle = app.clone();
                     tauri::async_runtime::spawn(async move {
                         for delay_ms in [100_u64, 500, 1200] {

--- a/AutoSubs-App/src-tauri/tauri.conf.json
+++ b/AutoSubs-App/src-tauri/tauri.conf.json
@@ -148,7 +148,7 @@
         },
         {
           "name": "density",
-          "description": "Subtitle text density (e.g. high, balanced, low, custom).",
+          "description": "Subtitle text density: less, standard, more, single, or custom.",
           "takesValue": true
         },
         {

--- a/AutoSubs-App/src-tauri/tauri.conf.json
+++ b/AutoSubs-App/src-tauri/tauri.conf.json
@@ -10,20 +10,7 @@
     "frontendDist": "../dist"
   },
   "app": {
-    "windows": [
-      {
-        "titleBarStyle": "Overlay",
-        "decorations": true,
-        "trafficLightPosition": {
-          "x": 16,
-          "y": 25
-        },
-        "height": 700,
-        "width": 750,
-        "acceptFirstMouse": true,
-        "zoomHotkeysEnabled": true
-      }
-    ],
+    "windows": [],
     "security": {
       "csp": null,
       "assetProtocol": {
@@ -98,6 +85,98 @@
     "createUpdaterArtifacts": true
   },
   "plugins": {
+    "cli": {
+      "description": "AutoSubs — transcribe and diarize an audio or video file to JSON. Run with no arguments to open the desktop app.",
+      "longDescription": "Transcribe a local audio or video file and print the transcript as JSON. Runs headlessly (no window) and exits when given arguments; with no arguments it launches the AutoSubs desktop interface.",
+      "args": [
+        {
+          "name": "input",
+          "description": "Path to the audio or video file to transcribe.",
+          "index": 1,
+          "takesValue": true,
+          "required": true
+        },
+        {
+          "name": "model",
+          "short": "m",
+          "description": "Whisper model to use (e.g. tiny, base, small, medium, large). Downloaded automatically if missing.",
+          "takesValue": true
+        },
+        {
+          "name": "output",
+          "short": "o",
+          "description": "Write to this file instead of stdout (format inferred from extension if --format is omitted).",
+          "takesValue": true
+        },
+        {
+          "name": "format",
+          "short": "f",
+          "description": "Output format: text (default), json, srt, or vtt.",
+          "takesValue": true
+        },
+        {
+          "name": "lang",
+          "short": "l",
+          "description": "Source language code (e.g. en). Auto-detected if omitted.",
+          "takesValue": true
+        },
+        {
+          "name": "translate",
+          "description": "Translate the transcript to English."
+        },
+        {
+          "name": "target-language",
+          "description": "Target language code for translation.",
+          "takesValue": true
+        },
+        {
+          "name": "diarize",
+          "description": "Enable speaker diarization."
+        },
+        {
+          "name": "max-speakers",
+          "description": "Maximum number of speakers when diarizing.",
+          "takesValue": true
+        },
+        {
+          "name": "gpu",
+          "description": "Force GPU acceleration on."
+        },
+        {
+          "name": "no-gpu",
+          "description": "Disable GPU acceleration (CPU only)."
+        },
+        {
+          "name": "density",
+          "description": "Subtitle text density (e.g. high, balanced, low, custom).",
+          "takesValue": true
+        },
+        {
+          "name": "max-lines",
+          "description": "Maximum lines per subtitle.",
+          "takesValue": true
+        },
+        {
+          "name": "max-chars-per-line",
+          "description": "Custom maximum characters per line (used with --density custom).",
+          "takesValue": true
+        },
+        {
+          "name": "text-case",
+          "description": "Text case: none, lowercase, uppercase, or titlecase.",
+          "takesValue": true
+        },
+        {
+          "name": "remove-punctuation",
+          "description": "Strip punctuation from the transcript."
+        },
+        {
+          "name": "prompt",
+          "description": "Custom prompt to guide transcription.",
+          "takesValue": true
+        }
+      ]
+    },
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEFENjNBQjZFRkVCQTQxQTkKUldTcFFiciticXRqcmZtTlRWRzdnSHhBMFVNZkxvOGFRZThXdXFNQjFzakxqNDF0bUFyWkhwckUK",
       "endpoints": [

--- a/AutoSubs-App/src/components/dialogs/settings-dialog.tsx
+++ b/AutoSubs-App/src/components/dialogs/settings-dialog.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Gauge, Clock, GraduationCap, Terminal } from "lucide-react";
 import { DeleteIcon, type DeleteIconHandle } from "@/components/ui/icons/delete";
 import { useSettings } from "@/contexts/SettingsContext";
-import { ask } from "@tauri-apps/plugin-dialog";
+import { ask, message } from "@tauri-apps/plugin-dialog";
 import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import {
@@ -63,6 +63,49 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
       console.error("[SettingsDialog] failed to open logs folder:", err);
     }
   }, []);
+
+  // Command-line tool ("autosubs" on PATH). Status is queried when the dialog
+  // opens; install/uninstall are handled by the backend per-platform.
+  type CliStatus = {
+    installed: boolean;
+    manageable: boolean;
+    location: string | null;
+    note: string | null;
+  };
+  const [cliStatus, setCliStatus] = React.useState<CliStatus | null>(null);
+  const [cliBusy, setCliBusy] = React.useState(false);
+
+  const refreshCliStatus = React.useCallback(async () => {
+    try {
+      setCliStatus(await invoke<CliStatus>("cli_command_status"));
+    } catch (err) {
+      console.error("[SettingsDialog] failed to read CLI status:", err);
+      setCliStatus(null);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    if (open) refreshCliStatus();
+  }, [open, refreshCliStatus]);
+
+  const handleCliToggle = React.useCallback(async () => {
+    if (!cliStatus?.manageable) return;
+    const command = cliStatus.installed ? "uninstall_cli_command" : "install_cli_command";
+    setCliBusy(true);
+    try {
+      setCliStatus(await invoke<CliStatus>(command));
+    } catch (err) {
+      const msg = String(err);
+      // User dismissing the macOS admin prompt is a normal, silent outcome.
+      if (msg !== "Cancelled.") {
+        console.error("[SettingsDialog] CLI install/uninstall failed:", err);
+        await message(msg, { title: t("settings.cli.errorTitle", "Command-line tool"), kind: "error" });
+      }
+      await refreshCliStatus();
+    } finally {
+      setCliBusy(false);
+    }
+  }, [cliStatus, refreshCliStatus, t]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -186,6 +229,56 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                 </Field>
               </FieldGroup>
             </div>
+
+            {/* Command-line tool */}
+            {cliStatus && (
+              <div className="space-y-3">
+                <h4 className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+                  {t("settings.sections.cli", "Command line")}
+                </h4>
+
+                <FieldGroup className="gap-3">
+                  <Field>
+                    <Item variant="outline" size="sm">
+                      <ItemMedia variant="icon" className="bg-green-100 dark:bg-green-900/30">
+                        <Terminal className="size-4 text-green-600 dark:text-green-400" />
+                      </ItemMedia>
+                      <ItemContent>
+                        <ItemTitle>{t("settings.cli.title", "Command-line tool")}</ItemTitle>
+                        <ItemDescription className="text-xs leading-tight line-clamp-2">
+                          {cliStatus.manageable
+                            ? t(
+                                "settings.cli.description",
+                                "Install the `autosubs` command so you can transcribe files from any terminal."
+                              )
+                            : cliStatus.note ?? ""}
+                        </ItemDescription>
+                      </ItemContent>
+                      <ItemActions>
+                        {cliStatus.manageable ? (
+                          <Button
+                            variant={cliStatus.installed ? "outline" : "secondary"}
+                            size="sm"
+                            disabled={cliBusy}
+                            onClick={handleCliToggle}
+                          >
+                            {cliStatus.installed
+                              ? t("settings.cli.remove", "Remove")
+                              : t("settings.cli.install", "Install")}
+                          </Button>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">
+                            {cliStatus.installed
+                              ? t("settings.cli.available", "Available")
+                              : t("settings.cli.notFound", "Not found")}
+                          </span>
+                        )}
+                      </ItemActions>
+                    </Item>
+                  </Field>
+                </FieldGroup>
+              </div>
+            )}
           </div>
 
           <DialogFooter>

--- a/README.md
+++ b/README.md
@@ -76,25 +76,55 @@ Download [AutoSubs-linux-x86_64.rpm](https://github.com/tmoroney/auto-subs/relea
 > [!WARNING]
 > AutoSubs will not work with the Mac App Store version of DaVinci Resolve. Re-install from the [official website](https://www.blackmagicdesign.com/products/davinciresolve/) if needed.
 
+### Command Line Interface
+
+AutoSubs can run from the terminal without opening a window, so AI agents and terminal-heavy users can transcribe files directly. Given a file argument the app runs headlessly, prints the result, and exits with a status code (`0` success, `1` on a runtime error, `2` on a usage error). With **no** arguments it launches the normal desktop interface.
+
+```bash
+# Readable transcript to the console (default format)
+autosubs interview.mp4 --model small
+
+# Speaker diarization (adds "Speaker N:" labels)
+autosubs interview.mp4 --diarize --max-speakers 2 --lang en
+
+# Pick a format explicitly…
+autosubs interview.mp4 -f srt
+autosubs interview.mp4 -f json
+
+# …or let the output file extension decide
+autosubs interview.mp4 -o subs.srt
+autosubs interview.mp4 -o transcript.json
+
+# Full option list / version
+autosubs --help
+autosubs --version
+```
+
+**Output formats** (`-f` / `--format`):
+
+| Format | Contents |
+|---|---|
+| `text` *(default)* | Readable transcript — `[HH:MM:SS] Speaker N: …`, one paragraph per speaker turn (no word-level timings) |
+| `srt` | SubRip subtitles (one short cue per segment) |
+| `vtt` | WebVTT subtitles (one short cue per segment) |
+| `json` | Full structured transcript including word-level timestamps |
+
+If `--format` is omitted, the format is inferred from the `-o` file extension (`.srt`, `.vtt`, `.json`, `.txt`), otherwise it defaults to `text`.
+
+**stdout** carries only the rendered output, so `autosubs file.mp4 -f srt > out.srt` is clean and pipe-safe. Progress and errors go to **stderr**: in an interactive terminal you get a live progress bar with the current stage (downloading model / transcribing / diarizing / translating); when stderr is piped or captured, it falls back to one line per stage. On failure a `{ "error": "..." }` object is printed to stderr and the exit code is non-zero. Models are downloaded automatically on first use to the app's cache directory.
+
+> On Windows, release builds attach to the parent console at startup so output is visible. As with any Tauri CLI app, the shell prompt may return before output finishes printing.
+
+#### Getting the `autosubs` command on your PATH
+
+The CLI is the same binary as the desktop app, so it needs to be reachable from your shell:
+
+- **Linux** — already done. The `.deb`/`.rpm` installs `/usr/bin/autosubs`, which is on `PATH`. Just run `autosubs <file> ...`.
+- **macOS / Windows** — open **Settings → Command line** in the app and click **Install**. This symlinks the command into `/usr/local/bin` (macOS, prompts for your password) or adds the install folder to your user `PATH` (Windows). **Remove** reverses it. The button reports the current state on each platform.
+
 ---
 
 ## Integrations
-
-```mermaid
-flowchart TD
-    app["AutoSubs Desktop App<br/>Local AI transcription"]
-    file["Standalone Files<br/>Audio / video input"]
-    resolve["DaVinci Resolve<br/>Lua script integration"]
-    adobe["Adobe Bridge + Extension<br/>WebSocket :8185"]
-    premiere["Premiere Pro<br/>Sequence audio + SRT captions"]
-    aftereffects["After Effects<br/>SRT to text layers"]
-
-    file --> app
-    app <--> resolve
-    app <--> adobe
-    adobe --> premiere
-    adobe --> aftereffects
-```
 
 AutoSubs can run as a standalone subtitle generator, connect directly to DaVinci Resolve, or communicate with Adobe Premiere Pro and After Effects through the bundled CEP extension.
 


### PR DESCRIPTION
## What

Adds a command-line interface so AI agents and terminal-heavy users can transcribe audio/video without the GUI. The desktop app and CLI are the **same binary**: given a file argument it runs headlessly (no window), renders the transcript, and exits with a status code; with no arguments it launches the desktop app exactly as before.

```bash
autosubs interview.mp4 --model small            # readable transcript to stdout
autosubs interview.mp4 --diarize -f srt -o subs.srt
autosubs --help / --version
```

## Why

The app's transcription engine already runs in Rust (`transcribe_audio`), but the only way to drive it was the GUI. Exposing it as a CLI makes it scriptable and agent-friendly with no duplicated logic.

## How it works

- **`tauri-plugin-cli`** + a flat `autosubs <input> [options]` command that calls the existing `transcribe_audio` pipeline in-process (ffmpeg normalize → model download → transcribe → diarize → format). No second binary, no duplicated orchestration.
- **Headless detection from argv before building**: headless runs skip the single-instance plugin, updater, and Adobe bridge, and **never create a webview**. The main GUI window is now built programmatically (only in GUI mode) instead of via `tauri.conf.json`. macOS dock icon is hidden in CLI mode.
- **Output formats** (`-f`/`--format`): `text` (default — readable transcript grouped into one paragraph per speaker turn, no word-level timings), `srt`, `vtt`, `json` (full, with word timestamps). Format is inferred from the `-o` extension when `--format` is omitted.
- **stdout/stderr discipline**: stdout carries only the rendered result (pipe-safe); progress goes to stderr — a live progress bar with the current stage on a TTY, or one line per stage when piped. Exit codes: `0` ok, `1` runtime error (`{"error":...}` on stderr), `2` usage error.
- **PATH install**: an in-app **Settings → Command line → Install** button puts `autosubs` on PATH per-platform (symlink into `/usr/local/bin` on macOS with an admin prompt; user PATH on Windows; Linux already gets `/usr/bin/autosubs` from the deb/rpm). No installer changes.
- **Windows**: attaches to the parent console so CLI output is visible despite the `windows` subsystem.

## Files

- `src-tauri/src/cli.rs` (new) — arg parsing, headless run, formats, progress, PATH install commands
- `src-tauri/src/main.rs` — headless branch, conditional plugins, programmatic window, dock policy
- `tauri.conf.json`, `Cargo.toml`, `capabilities/default.json` — plugin + CLI arg schema + permission
- `settings-dialog.tsx` — "Command line" install/remove UI
- READMEs — CLI docs

## Reviewer notes

- Verified on macOS: help/version, `text`/`srt`/`vtt`/`json`, extension inference, usage errors, diarization labels, no window during runs, GUI still launches.
- **Only the macOS code paths were compiled/run here.** The Windows (PowerShell user-PATH, `AttachConsole`) and Linux (`which`) branches are `#[cfg]`-gated and should be confirmed in CI / a platform build.
- GUI window is now created in Rust rather than config — worth an eyeball that the traffic-light position and overlay titlebar still look right on macOS.
- True *displayless* Linux servers aren't supported (Tauri's event loop still needs a display); a Tauri-free binary would be a future option if needed.