### PR TITLE
fix: use GetEnvironmentVariableW to handle special characters in Windows username paths

### DIFF
--- a/AutoSubs-App/src-tauri/resources/AutoSubs.lua
+++ b/AutoSubs-App/src-tauri/resources/AutoSubs.lua
@@ -80,10 +80,31 @@ if os_name == "Windows" then
         void* _wfopen(const WCHAR* filename, const WCHAR* mode);
         size_t fread(void* buffer, size_t size, size_t count, void* stream);
         int fclose(void* stream);
+
+        unsigned long GetEnvironmentVariableW(const WCHAR* lpName, WCHAR* lpBuffer, unsigned long nSize);
+        int WideCharToMultiByte(unsigned int CodePage, unsigned long dwFlags,
+            const WCHAR* lpWideCharStr, int cchWideChar,
+            char* lpMultiByteStr, int cbMultiByte,
+            const char* lpDefaultChar, int* lpUsedDefaultChar);
     ]]
 
+    -- Use the Wide API to get environment variables so special characters in
+    -- usernames (e.g. accented letters) are not corrupted by the ANSI fallback.
+    local function getenv_wide(name)
+        local wide_name = to_wide_string(name)
+        local size = ffi.C.GetEnvironmentVariableW(wide_name, nil, 0)
+        if size == 0 then return nil end
+        local buffer = ffi.new("WCHAR[?]", size)
+        ffi.C.GetEnvironmentVariableW(wide_name, buffer, size)
+        local utf8_size = ffi.C.WideCharToMultiByte(65001, 0, buffer, -1, nil, 0, nil, nil)
+        if utf8_size == 0 then return nil end
+        local utf8_buffer = ffi.new("char[?]", utf8_size)
+        ffi.C.WideCharToMultiByte(65001, 0, buffer, -1, utf8_buffer, utf8_size, nil, nil)
+        return ffi.string(utf8_buffer, utf8_size - 1)
+    end
+
     -- Get path to the main AutoSubs app and modules
-    local storage_path = os.getenv("APPDATA") ..
+    local storage_path = getenv_wide("APPDATA") ..
         "\\Blackmagic Design\\DaVinci Resolve\\Support\\Fusion\\Scripts\\Utility\\AutoSubs"
     local install_path = assert(read_file(join_path(storage_path, "install_path.txt")))
     app_executable = install_path .. "\\AutoSubs.exe"


### PR DESCRIPTION
os.getenv() uses the ANSI API on Windows, which corrupts non-ASCII characters
(e.g. accented letters) in usernames, causing the APPDATA path to contain '?'
and making _wfopen fail to open install_path.txt.

Fix by declaring GetEnvironmentVariableW and WideCharToMultiByte via FFI and
using them to retrieve APPDATA as UTF-16, then converting to UTF-8 — consistent
with the existing _wfopen approach for file reads.

Fixes #556

https://claude.ai/code/session_01EDNDi9KSaJZfXkYApiPF2R