### PR TITLE
fix: enable model downloads through VPN and system proxies

### DIFF
--- a/AutoSubs-App/src-tauri/Cargo.lock
+++ b/AutoSubs-App/src-tauri/Cargo.lock
@@ -329,6 +329,7 @@ dependencies = [
  "tracing-subscriber",
  "transcription-engine",
  "which 6.0.3",
+ "winreg 0.55.0",
 ]
 
 [[package]]

--- a/AutoSubs-App/src-tauri/Cargo.toml
+++ b/AutoSubs-App/src-tauri/Cargo.toml
@@ -77,6 +77,9 @@ tauri-plugin-updater = "2"
 cocoa = "0.26"
 objc = "0.2"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+winreg = "0.55"
+
 [features]
 default = ["mac-aarch"]
 mac-aarch = ["transcription-engine/mac-aarch"]

--- a/AutoSubs-App/src-tauri/crates/transcription-engine/src/model_manager.rs
+++ b/AutoSubs-App/src-tauri/crates/transcription-engine/src/model_manager.rs
@@ -456,14 +456,20 @@ impl ModelManager {
                 cb(offset as i32, ProgressType::Download, "progressSteps.download");
             }
 
+            let hf_endpoint = std::env::var("HF_ENDPOINT")
+                .unwrap_or_else(|_| "https://huggingface.co".to_string());
+            let hf_endpoint = hf_endpoint.trim_end_matches('/');
             let url = if *filename == "tokenizer.json" {
                 // The HF repo currently does not provide tokenizer.json under tiny/* variants.
                 // Tokenizer assets live under base/float and appear to be shared.
-                "https://huggingface.co/UsefulSensors/moonshine/resolve/main/onnx/merged/base/float/tokenizer.json".to_string()
+                format!(
+                    "{}/UsefulSensors/moonshine/resolve/main/onnx/merged/base/float/tokenizer.json",
+                    hf_endpoint
+                )
             } else {
                 format!(
-                    "https://huggingface.co/UsefulSensors/moonshine/resolve/main/onnx/merged/{}/{}/{}",
-                    folder, onnx_subdir, filename
+                    "{}/UsefulSensors/moonshine/resolve/main/onnx/merged/{}/{}/{}",
+                    hf_endpoint, folder, onnx_subdir, filename
                 )
             };
             download_to(&dest, &url).await?;
@@ -496,9 +502,15 @@ impl ModelManager {
         progress: Option<&LabeledProgressFn>,
         is_cancelled: Option<&(dyn Fn() -> bool + Send + Sync)>,
     ) -> Result<PathBuf> {
-        const VAD_URL: &str =
-            "https://huggingface.co/ggml-org/whisper-vad/resolve/main/ggml-silero-v5.1.2.bin";
         const VAD_TIMEOUT_SECS: u64 = 120;
+
+        let hf_endpoint = std::env::var("HF_ENDPOINT")
+            .unwrap_or_else(|_| "https://huggingface.co".to_string());
+        let hf_endpoint = hf_endpoint.trim_end_matches('/');
+        let vad_url = format!(
+            "{}/ggml-org/whisper-vad/resolve/main/ggml-silero-v5.1.2.bin",
+            hf_endpoint
+        );
 
         if let Some(is_cancelled) = is_cancelled {
             if is_cancelled() { bail!("Cancelled"); }
@@ -525,7 +537,7 @@ impl ModelManager {
 
         match tokio::time::timeout(
             std::time::Duration::from_secs(VAD_TIMEOUT_SECS),
-            download_to(&dest, VAD_URL),
+            download_to(&dest, &vad_url),
         )
         .await
         {
@@ -995,7 +1007,9 @@ impl ModelManager {
             }
         }
 
-        let api = ApiBuilder::new()
+        // from_env() reads HF_ENDPOINT (custom HuggingFace mirror) and HF_HOME from the
+        // environment. with_cache_dir() overrides HF_HOME so our own cache location is used.
+        let api = ApiBuilder::from_env()
             .with_cache_dir(cache_dir)
             .build()
             .with_context(|| format!("Failed to build hf-hub API for repo '{}'", repo_id))?;

--- a/AutoSubs-App/src-tauri/src/main.rs
+++ b/AutoSubs-App/src-tauri/src/main.rs
@@ -119,6 +119,36 @@ fn setup_proxy_env() {
             std::env::set_var("https_proxy", url);
         }
     }
+
+    // Build NO_PROXY from the WinINet ProxyOverride list so that local
+    // connections (Resolve bridge on 127.0.0.1:56002, etc.) are never
+    // routed through the proxy. Always include loopback addresses even if
+    // ProxyOverride is absent; WinINet's "<local>" sentinel is replaced
+    // with the canonical addresses that ureq/reqwest understand.
+    let existing_no_proxy = std::env::var_os("NO_PROXY")
+        .or_else(|| std::env::var_os("no_proxy"))
+        .is_some();
+    if !existing_no_proxy {
+        let mut no_proxy_entries: Vec<String> =
+            vec!["127.0.0.1".into(), "localhost".into(), "::1".into()];
+
+        if let Ok(override_val) = ie.get_value::<String, _>("ProxyOverride") {
+            for entry in override_val.split(';') {
+                let entry = entry.trim();
+                if entry.is_empty() || entry.eq_ignore_ascii_case("<local>") {
+                    // <local> is already covered by the loopback entries above.
+                    continue;
+                }
+                no_proxy_entries.push(entry.to_string());
+            }
+        }
+
+        let no_proxy = no_proxy_entries.join(",");
+        unsafe {
+            std::env::set_var("NO_PROXY", &no_proxy);
+            std::env::set_var("no_proxy", &no_proxy);
+        }
+    }
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/AutoSubs-App/src-tauri/src/main.rs
+++ b/AutoSubs-App/src-tauri/src/main.rs
@@ -91,6 +91,11 @@ fn setup_proxy_env() {
         }
     };
 
+    // Parse HTTP_PROXY / HTTPS_PROXY from the ProxyServer value.
+    // ProxyServer is either a bare "host:port" (applies to all protocols, use as HTTP proxy)
+    // or a semicolon-separated "proto=host:port" list. Only map http/https entries —
+    // never fall back to socks entries, because reqwest has no SOCKS support in this build
+    // and speaking HTTP proxy protocol to a SOCKS listener causes immediate failures.
     let (http_url, https_url) = if server.contains('=') {
         let find = |proto: &str| -> Option<String> {
             server
@@ -99,10 +104,12 @@ fn setup_proxy_env() {
                 .and_then(|s| s.splitn(2, '=').nth(1))
                 .map(|addr| make_url(addr))
         };
-        let http = find("http").or_else(|| find("socks"));
-        let https = find("https").or_else(|| find("http")).or_else(|| find("socks"));
+        // Only use explicitly named http/https entries; skip socks-only configurations.
+        let http = find("http");
+        let https = find("https").or_else(|| find("http"));
         (http, https)
     } else {
+        // Bare "host:port" means use for all protocols including HTTP — this is correct.
         let url = make_url(&server);
         (Some(url.clone()), Some(url))
     };

--- a/AutoSubs-App/src-tauri/src/main.rs
+++ b/AutoSubs-App/src-tauri/src/main.rs
@@ -42,6 +42,89 @@ mod tests;
 // Global guard to avoid re-entrant exit handling
 static EXITING: AtomicBool = AtomicBool::new(false);
 
+/// Read the Windows system proxy from the Internet Settings registry key and inject it
+/// into the process environment as HTTP_PROXY / HTTPS_PROXY so that HTTP clients that
+/// read proxy settings from env vars (ureq used by hf-hub, reqwest) can use the proxy
+/// that VPN and proxy software configures via Windows Settings.
+///
+/// Only runs when the env vars are not already set, so explicit overrides (e.g. from a
+/// launch script) are always preserved.
+#[cfg(target_os = "windows")]
+fn setup_proxy_env() {
+    let already_set = std::env::var_os("HTTP_PROXY").is_some()
+        || std::env::var_os("HTTPS_PROXY").is_some()
+        || std::env::var_os("http_proxy").is_some()
+        || std::env::var_os("https_proxy").is_some()
+        || std::env::var_os("ALL_PROXY").is_some();
+    if already_set {
+        return;
+    }
+
+    use winreg::enums::*;
+    use winreg::RegKey;
+
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    let Ok(ie) = hkcu.open_subkey("Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings") else {
+        return;
+    };
+
+    let enabled: u32 = ie.get_value("ProxyEnable").unwrap_or(0u32);
+    if enabled == 0 {
+        return;
+    }
+
+    let server: String = match ie.get_value("ProxyServer") {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    if server.is_empty() {
+        return;
+    }
+
+    // ProxyServer is either a bare "host:port" or a semicolon-separated
+    // "proto=host:port" list (e.g. "http=127.0.0.1:8080;https=127.0.0.1:8080;socks=127.0.0.1:1080").
+    let make_url = |addr: &str| -> String {
+        if addr.starts_with("http://") || addr.starts_with("https://") || addr.starts_with("socks") {
+            addr.to_string()
+        } else {
+            format!("http://{}", addr)
+        }
+    };
+
+    let (http_url, https_url) = if server.contains('=') {
+        let find = |proto: &str| -> Option<String> {
+            server
+                .split(';')
+                .find(|s| s.to_ascii_lowercase().starts_with(&format!("{}=", proto)))
+                .and_then(|s| s.splitn(2, '=').nth(1))
+                .map(|addr| make_url(addr))
+        };
+        let http = find("http").or_else(|| find("socks"));
+        let https = find("https").or_else(|| find("http")).or_else(|| find("socks"));
+        (http, https)
+    } else {
+        let url = make_url(&server);
+        (Some(url.clone()), Some(url))
+    };
+
+    if let Some(ref url) = http_url {
+        unsafe {
+            std::env::set_var("HTTP_PROXY", url);
+            std::env::set_var("http_proxy", url);
+        }
+    }
+    if let Some(ref url) = https_url {
+        unsafe {
+            std::env::set_var("HTTPS_PROXY", url);
+            std::env::set_var("https_proxy", url);
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn setup_proxy_env() {}
+
+
 #[cfg(target_os = "linux")]
 fn is_newer_version(latest: &str, current: &str) -> bool {
     let parse = |s: &str| -> Option<(u32, u32, u32)> {
@@ -99,6 +182,11 @@ fn create_main_window(app: &tauri::AppHandle) -> tauri::Result<tauri::WebviewWin
 }
 
 fn main() {
+    // Inject system proxy env vars before any thread or HTTP client is created so
+    // that both ureq (hf-hub) and reqwest pick up the Windows system proxy set by
+    // VPN software via WinINet.
+    setup_proxy_env();
+
     // Route whisper.cpp C-side logs through Rust's tracing system so they can be
     // filtered rather than being dumped raw to stderr.
     transcription_engine::install_logging_hooks();


### PR DESCRIPTION
Three separate but related fixes:

1. Windows system proxy detection: Read the WinINet proxy settings from
   the registry (Internet Settings/ProxyEnable + ProxyServer) at startup
   and inject them as HTTP_PROXY/HTTPS_PROXY environment variables. VPN
   and proxy software (e.g. Trojan-GO, Clash) configure the Windows
   system proxy via this registry key but do NOT set process env vars,
   so HTTP clients like ureq (used by hf-hub) and reqwest would never
   see the proxy. Env vars already set by the user (e.g. via a launch
   script) are preserved and take precedence.

2. HF_ENDPOINT support: Switch hf-hub ApiBuilder from new() to from_env()
   so that the HF_ENDPOINT environment variable is honoured. Users in
   regions where huggingface.co is blocked can now point the app at a
   mirror (e.g. hf-mirror.com) by setting HF_ENDPOINT before launch.

3. Moonshine/VAD URL env var: The Moonshine and VAD model downloads use
   direct reqwest URLs hardcoded to https://huggingface.co. These now
   read HF_ENDPOINT at runtime so all model downloads go through the
   same mirror when one is configured.

Closes #546, #550, #551, #553 (VPN download failures).
References discussion #561.

https://claude.ai/code/session_01GguyHkzhv6YKC9c2GSGryH