### PR TITLE
Simplify custom prompt UI to single textarea with language warning

### DIFF
--- a/AutoSubs-App/src/components/transcription/options-row.tsx
+++ b/AutoSubs-App/src/components/transcription/options-row.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Info, ScrollText, Speech, Type } from "lucide-react";
+import { ScrollText, Speech, Type } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
@@ -8,18 +8,12 @@ import {
   PopoverTrigger,
   PopoverContent,
 } from "@/components/ui/popover";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { Textarea } from "@/components/ui/textarea";
 import { SpeakerSelector } from "@/components/settings/diarize-selector";
 import { TextFormattingPanel } from "@/components/settings/text-formatting-panel";
 import { useSettings } from "@/contexts/SettingsContext";
 import { cn } from "@/lib/utils";
-import { composeCustomPrompt, parseCustomPrompt } from "./utils";
+import { migrateCustomPrompt } from "./utils";
 
 export function OptionsRow() {
   const { t } = useTranslation();
@@ -158,31 +152,21 @@ function CustomPromptPopover({
   onCustomPromptChange,
 }: CustomPromptPopoverProps) {
   const { t } = useTranslation();
-  const [localTerms, setLocalTerms] = React.useState("");
-  const [localContext, setLocalContext] = React.useState("");
+  const [localPrompt, setLocalPrompt] = React.useState("");
 
-  const customPromptParts = React.useMemo(
-    () => parseCustomPrompt(customPrompt),
-    [customPrompt],
-  );
-
-  // Sync local state when popover opens
+  // Sync local state when popover opens, migrating any legacy two-section format
   React.useEffect(() => {
     if (open) {
-      setLocalTerms(customPromptParts.terms);
-      setLocalContext(customPromptParts.context);
+      setLocalPrompt(migrateCustomPrompt(customPrompt));
     }
-  }, [open, customPromptParts.terms, customPromptParts.context]);
+  }, [open, customPrompt]);
 
   // Sync to settings when popover closes
   React.useEffect(() => {
     if (open) return;
-
-    const nextCustomPrompt = composeCustomPrompt(localTerms, localContext);
-    if (nextCustomPrompt === customPrompt) return;
-
-    onCustomPromptChange(nextCustomPrompt);
-  }, [open, localTerms, localContext, customPrompt, onCustomPromptChange]);
+    if (localPrompt === customPrompt) return;
+    onCustomPromptChange(localPrompt);
+  }, [open, localPrompt, customPrompt, onCustomPromptChange]);
 
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
@@ -218,7 +202,7 @@ function CustomPromptPopover({
         align="center"
         onOpenAutoFocus={(e) => e.preventDefault()}
       >
-        <div className="px-4 py-3.5 space-y-4">
+        <div className="px-4 py-3.5 space-y-3">
           <div className="space-y-0.5">
             <Label className="text-sm font-medium">
               {t("actionBar.format.customPromptTitle")}
@@ -227,60 +211,17 @@ function CustomPromptPopover({
               {t("actionBar.format.customPromptDescription")}
             </p>
           </div>
-          <div className="space-y-1.5">
-            <div className="flex items-center gap-1.5">
-              <Label className="text-xs font-medium">
-                {t("actionBar.format.customPromptTermsTitle")}
-              </Label>
-              <TooltipProvider delayDuration={300}>
-                <Tooltip>
-                  <TooltipTrigger>
-                    <Info className="size-3.5 text-muted-foreground cursor-help" />
-                  </TooltipTrigger>
-                  <TooltipContent className="max-w-[220px]">
-                    <p className="text-xs">
-                      {t("actionBar.format.customPromptTermsExample")}
-                    </p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            </div>
-            <Textarea
-              value={localTerms}
-              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                setLocalTerms(e.target.value)
-              }
-              placeholder={t("actionBar.format.customPromptTermsPlaceholder")}
-              className="min-h-[76px] resize-none text-sm"
-            />
-          </div>
-          <div className="space-y-1.5">
-            <div className="flex items-center gap-1.5">
-              <Label className="text-xs font-medium">
-                {t("actionBar.format.customPromptContextTitle")}
-              </Label>
-              <TooltipProvider delayDuration={300}>
-                <Tooltip>
-                  <TooltipTrigger>
-                    <Info className="size-3.5 text-muted-foreground cursor-help" />
-                  </TooltipTrigger>
-                  <TooltipContent className="max-w-[255px]">
-                    <p className="text-xs">
-                      {t("actionBar.format.customPromptContextExample")}
-                    </p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            </div>
-            <Textarea
-              value={localContext}
-              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                setLocalContext(e.target.value)
-              }
-              placeholder={t("actionBar.format.customPromptContextPlaceholder")}
-              className="min-h-[64px] resize-none text-sm"
-            />
-          </div>
+          <Textarea
+            value={localPrompt}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+              setLocalPrompt(e.target.value)
+            }
+            placeholder={t("actionBar.format.customPromptPlaceholder")}
+            className="min-h-[100px] resize-none text-sm"
+          />
+          <p className="text-xs text-amber-600 dark:text-amber-500">
+            {t("actionBar.format.customPromptLanguageWarning")}
+          </p>
         </div>
         <div className="border-t bg-muted/30">
           <div className="px-4 py-3">

--- a/AutoSubs-App/src/components/transcription/utils.ts
+++ b/AutoSubs-App/src/components/transcription/utils.ts
@@ -49,7 +49,13 @@ const LEGACY_TERMS_HEADER = "Key terms and preferred spellings:";
 const LEGACY_CONTEXT_HEADER = "Context / style note:";
 
 // Strips old two-section headers from prompts saved before the UI was simplified.
+// Only migrates values that start with a legacy header — the old composeCustomPrompt
+// always emitted one first — so newly authored prompts that happen to contain the
+// header phrases are left untouched.
 export function migrateCustomPrompt(value: string): string {
+  if (!value.startsWith(LEGACY_TERMS_HEADER) && !value.startsWith(LEGACY_CONTEXT_HEADER)) {
+    return value;
+  }
   return value
     .replace(new RegExp(`${LEGACY_TERMS_HEADER}\\n?`, "g"), "")
     .replace(new RegExp(`${LEGACY_CONTEXT_HEADER}\\n?`, "g"), "")

--- a/AutoSubs-App/src/components/transcription/utils.ts
+++ b/AutoSubs-App/src/components/transcription/utils.ts
@@ -45,83 +45,16 @@ export function isSupportedMediaFile(filePath: string): boolean {
   return extension ? SUPPORTED_MEDIA_EXTENSIONS.includes(extension) : false;
 }
 
-const CUSTOM_PROMPT_TERMS_HEADER = "Key terms and preferred spellings:";
-const CUSTOM_PROMPT_CONTEXT_HEADER = "Context / style note:";
-const CUSTOM_PROMPT_EXAMPLE_TERMS = "OpenAI, DaVinci Resolve, SubSlate, FFmpeg";
-const CUSTOM_PROMPT_EXAMPLE_CONTEXT =
-  "This is a tutorial about editing subtitles in DaVinci Resolve. Prefer “AutoSubs”, not “Auto Subs”.";
+const LEGACY_TERMS_HEADER = "Key terms and preferred spellings:";
+const LEGACY_CONTEXT_HEADER = "Context / style note:";
 
-function normalizeExampleText(value: string): string {
-  return value.replace(/"/g, "“");
-}
-
-function scrubExampleValue(value: string, example: string): string {
-  return normalizeExampleText(value) === normalizeExampleText(example)
-    ? ""
-    : value;
-}
-
-export function parseCustomPrompt(value: string): {
-  terms: string;
-  context: string;
-} {
-  const prompt = value;
-  if (!prompt.trim()) return { terms: "", context: "" };
-
-  const termsIndex = prompt.indexOf(CUSTOM_PROMPT_TERMS_HEADER);
-  const contextIndex = prompt.indexOf(CUSTOM_PROMPT_CONTEXT_HEADER);
-
-  if (termsIndex === -1 && contextIndex === -1) {
-    return { terms: prompt, context: "" };
-  }
-
-  let terms = "";
-  let context = "";
-
-  if (termsIndex !== -1) {
-    const termsStart = termsIndex + CUSTOM_PROMPT_TERMS_HEADER.length;
-    let termsEnd = contextIndex === -1 ? prompt.length : contextIndex;
-    if (contextIndex !== -1) {
-      const doubleNewlineBeforeContext = prompt.lastIndexOf(
-        "\n\n",
-        contextIndex,
-      );
-      if (doubleNewlineBeforeContext > termsStart) {
-        termsEnd = doubleNewlineBeforeContext;
-      }
-    }
-    terms = prompt.slice(termsStart, termsEnd);
-    if (terms.startsWith("\n")) {
-      terms = terms.slice(1);
-    }
-  }
-
-  if (contextIndex !== -1) {
-    const contextStart = contextIndex + CUSTOM_PROMPT_CONTEXT_HEADER.length;
-    context = prompt.slice(contextStart);
-    if (context.startsWith("\n")) {
-      context = context.slice(1);
-    }
-  }
-
-  return {
-    terms: scrubExampleValue(terms, CUSTOM_PROMPT_EXAMPLE_TERMS),
-    context: scrubExampleValue(context, CUSTOM_PROMPT_EXAMPLE_CONTEXT),
-  };
-}
-
-export function composeCustomPrompt(terms: string, context: string): string {
-  const sections: string[] = [];
-
-  if (terms.length > 0) {
-    sections.push(`${CUSTOM_PROMPT_TERMS_HEADER}\n${terms}`);
-  }
-
-  if (context.length > 0) {
-    sections.push(`${CUSTOM_PROMPT_CONTEXT_HEADER}\n${context}`);
-  }
-
-  return sections.join("\n\n");
+// Strips old two-section headers from prompts saved before the UI was simplified.
+export function migrateCustomPrompt(value: string): string {
+  return value
+    .replace(new RegExp(`${LEGACY_TERMS_HEADER}\\n?`, "g"), "")
+    .replace(new RegExp(`${LEGACY_CONTEXT_HEADER}\\n?`, "g"), "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
 }
 
 export interface ProcessingStep {

--- a/AutoSubs-App/src/i18n/locales/de/translation.json
+++ b/AutoSubs-App/src/i18n/locales/de/translation.json
@@ -113,13 +113,9 @@
       "customCharsDescription": "Zeichen pro Zeile",
       "customPromptButton": "Prompt",
       "customPromptTitle": "Vokabular & Kontext",
-      "customPromptDescription": "Hilft Whisper, Namen, Marken, Fachsprache, Akronyme und bevorzugte Schreibweisen zu erkennen.",
-      "customPromptTermsTitle": "Wichtige Begriffe",
-      "customPromptTermsPlaceholder": "Namen, Marken, Akronyme oder Fachbegriffe eingeben...",
-      "customPromptTermsExample": "Beispiel: OpenAI, DaVinci Resolve, SubSlate, FFmpeg",
-      "customPromptContextTitle": "Kontext / Stilhinweis",
-      "customPromptContextPlaceholder": "Kurzes Thema oder bevorzugte Schreibweise eingeben...",
-      "customPromptContextExample": "Beispiel: Dies ist ein DaVinci Resolve Tutorial. Schreibe lieber „AutoSubs“ statt „Auto Subs“.",
+      "customPromptDescription": "Begriffe, Namen oder Kontext hinzufügen, um Whisper zu leiten.",
+      "customPromptPlaceholder": "Z.B. OpenAI, DaVinci Resolve – Tutorial über Untertitelbearbeitung.",
+      "customPromptLanguageWarning": "In der gleichen Sprache wie das Audio schreiben – ein Prompt in einer anderen Sprache kann zu falschen Transkriptionen führen.",
       "customPromptWhisperOnly": "Nur von Whisper-Modellen unterstuetzt."
     },
     "censor": {

--- a/AutoSubs-App/src/i18n/locales/en/translation.json
+++ b/AutoSubs-App/src/i18n/locales/en/translation.json
@@ -113,13 +113,9 @@
       "customCharsDescription": "Characters per line",
       "customPromptButton": "Prompt",
       "customPromptTitle": "Vocabulary & Context",
-      "customPromptDescription": "Helps Whisper recognize names, brands, jargon, acronyms, and preferred spellings.",
-      "customPromptTermsTitle": "Key Terms",
-      "customPromptTermsPlaceholder": "Add names, brands, acronyms, or jargon...",
-      "customPromptTermsExample": "Example: OpenAI, DaVinci Resolve, SubSlate, FFmpeg",
-      "customPromptContextTitle": "Context / Style Note",
-      "customPromptContextPlaceholder": "Add a short topic or spelling preference...",
-      "customPromptContextExample": "Example: This is a DaVinci Resolve tutorial. Prefer “AutoSubs”, not “Auto Subs”.",
+      "customPromptDescription": "Add terms, names, or context to guide Whisper.",
+      "customPromptPlaceholder": "E.g. OpenAI, DaVinci Resolve — tutorial about subtitle editing.",
+      "customPromptLanguageWarning": "Write in the same language as your audio — a prompt in a different language can cause incorrect transcription.",
       "customPromptWhisperOnly": "Only supported by Whisper models."
     },
     "censor": {

--- a/AutoSubs-App/src/i18n/locales/es/translation.json
+++ b/AutoSubs-App/src/i18n/locales/es/translation.json
@@ -113,13 +113,9 @@
       "customCharsDescription": "Caracteres por línea",
       "customPromptButton": "Prompt",
       "customPromptTitle": "Vocabulario y contexto",
-      "customPromptDescription": "Ayuda a Whisper a reconocer nombres, marcas, jerga, acrónimos y grafías preferidas.",
-      "customPromptTermsTitle": "Términos clave",
-      "customPromptTermsPlaceholder": "Añade nombres, marcas, acrónimos o jerga...",
-      "customPromptTermsExample": "Ejemplo: OpenAI, DaVinci Resolve, SubSlate, FFmpeg",
-      "customPromptContextTitle": "Contexto / nota de estilo",
-      "customPromptContextPlaceholder": "Añade un tema breve o una preferencia de escritura...",
-      "customPromptContextExample": "Ejemplo: Tutorial de DaVinci Resolve. Prefiere “AutoSubs”, no “Auto Subs”.",
+      "customPromptDescription": "Agrega términos, nombres o contexto para guiar a Whisper.",
+      "customPromptPlaceholder": "Ej.: OpenAI, DaVinci Resolve — tutorial de edición de subtítulos en Resolve.",
+      "customPromptLanguageWarning": "Escribe en el mismo idioma que tu audio — un prompt en otro idioma puede causar una transcripción incorrecta.",
       "customPromptWhisperOnly": "Solo es compatible con modelos Whisper."
     },
     "censor": {

--- a/AutoSubs-App/src/i18n/locales/fr/translation.json
+++ b/AutoSubs-App/src/i18n/locales/fr/translation.json
@@ -113,13 +113,9 @@
       "customCharsDescription": "Caractères par ligne",
       "customPromptButton": "Prompt",
       "customPromptTitle": "Vocabulaire et contexte",
-      "customPromptDescription": "Aide Whisper à reconnaître les noms, marques, jargon, acronymes et orthographes préférées.",
-      "customPromptTermsTitle": "Termes clés",
-      "customPromptTermsPlaceholder": "Ajoutez des noms, marques, acronymes ou jargon...",
-      "customPromptTermsExample": "Exemple : OpenAI, DaVinci Resolve, SubSlate, FFmpeg",
-      "customPromptContextTitle": "Contexte / note de style",
-      "customPromptContextPlaceholder": "Ajoutez un sujet court ou une préférence d’orthographe...",
-      "customPromptContextExample": "Exemple : Tutoriel DaVinci Resolve. Préférer « AutoSubs » plutôt que « Auto Subs ».",
+      "customPromptDescription": "Ajoutez des termes, noms ou contexte pour guider Whisper.",
+      "customPromptPlaceholder": "Ex. : OpenAI, DaVinci Resolve — tutoriel sur le sous-titrage dans Resolve.",
+      "customPromptLanguageWarning": "Rédigez dans la même langue que votre audio — un prompt dans une autre langue peut entraîner une transcription incorrecte.",
       "customPromptWhisperOnly": "Pris en charge uniquement par les modèles Whisper."
     },
     "censor": {

--- a/AutoSubs-App/src/i18n/locales/ja/translation.json
+++ b/AutoSubs-App/src/i18n/locales/ja/translation.json
@@ -52,13 +52,9 @@
       "customCharsDescription": "1行あたりの文字数",
       "customPromptButton": "プロンプト",
       "customPromptTitle": "語彙とコンテキスト",
-      "customPromptDescription": "Whisperが名前、ブランド、専門用語、略語、優先表記を認識しやすくします。",
-      "customPromptTermsTitle": "重要な用語",
-      "customPromptTermsPlaceholder": "名前、ブランド、略語、専門用語を入力...",
-      "customPromptTermsExample": "例: OpenAI, DaVinci Resolve, SubSlate, FFmpeg",
-      "customPromptContextTitle": "コンテキスト / スタイルメモ",
-      "customPromptContextPlaceholder": "短い話題や表記の希望を入力...",
-      "customPromptContextExample": "例: DaVinci Resolveのチュートリアルです。「Auto Subs」ではなく「AutoSubs」を優先してください。",
+      "customPromptDescription": "Whisperを導くための用語、名前、またはコンテキストを追加します。",
+      "customPromptPlaceholder": "例: OpenAI, DaVinci Resolve — Resolveでのサブタイトル編集チュートリアル。",
+      "customPromptLanguageWarning": "音声と同じ言語で書いてください — 異なる言語のプロンプトは誤った文字起こしを引き起こす可能性があります。",
       "customPromptWhisperOnly": "Whisperモデルでのみサポートされています。"
     },
     "language": {

--- a/AutoSubs-App/src/i18n/locales/ko/translation.json
+++ b/AutoSubs-App/src/i18n/locales/ko/translation.json
@@ -55,13 +55,9 @@
       "customCharsDescription": "줄당 문자 수",
       "customPromptButton": "프롬프트",
       "customPromptTitle": "어휘 및 맥락",
-      "customPromptDescription": "Whisper가 이름, 브랜드, 전문 용어, 약어, 선호 표기를 더 잘 인식하도록 돕습니다.",
-      "customPromptTermsTitle": "주요 용어",
-      "customPromptTermsPlaceholder": "이름, 브랜드, 약어 또는 전문 용어 입력...",
-      "customPromptTermsExample": "예: OpenAI, DaVinci Resolve, SubSlate, FFmpeg",
-      "customPromptContextTitle": "맥락 / 스타일 메모",
-      "customPromptContextPlaceholder": "짧은 주제나 선호 표기 입력...",
-      "customPromptContextExample": "예: DaVinci Resolve 튜토리얼입니다. “Auto Subs”보다 “AutoSubs” 표기를 선호합니다.",
+      "customPromptDescription": "Whisper를 안내하기 위한 용어, 이름 또는 맥락을 추가하세요.",
+      "customPromptPlaceholder": "예: OpenAI, DaVinci Resolve — Resolve의 자막 편집 튜토리얼.",
+      "customPromptLanguageWarning": "오디오와 같은 언어로 작성하세요 — 다른 언어의 프롬프트는 잘못된 전사를 유발할 수 있습니다.",
       "customPromptWhisperOnly": "Whisper 모델에서만 지원됩니다."
     },
     "language": {

--- a/AutoSubs-App/src/i18n/locales/zh/translation.json
+++ b/AutoSubs-App/src/i18n/locales/zh/translation.json
@@ -113,13 +113,9 @@
       "customCharsDescription": "每行字符数",
       "customPromptButton": "提示",
       "customPromptTitle": "词汇和上下文",
-      "customPromptDescription": "帮助 Whisper 识别名称、品牌、术语、缩写和首选拼写。",
-      "customPromptTermsTitle": "关键术语",
-      "customPromptTermsPlaceholder": "添加名称、品牌、缩写或术语...",
-      "customPromptTermsExample": "示例：OpenAI, DaVinci Resolve, SubSlate, FFmpeg",
-      "customPromptContextTitle": "上下文 / 风格说明",
-      "customPromptContextPlaceholder": "添加简短主题或拼写偏好...",
-      "customPromptContextExample": "示例：这是 DaVinci Resolve 教程。优先使用“AutoSubs”，而不是“Auto Subs”。",
+      "customPromptDescription": "添加术语、名称或上下文以引导 Whisper。",
+      "customPromptPlaceholder": "例如：OpenAI, DaVinci Resolve — Resolve 字幕编辑教程。",
+      "customPromptLanguageWarning": "请使用与音频相同的语言书写 — 使用不同语言的提示可能导致转录错误。",
       "customPromptWhisperOnly": "仅 Whisper 模型支持。"
     },
     "censor": {


### PR DESCRIPTION
The two-section design (Key Terms + Context) prepended English section
headers to the prompt string before sending it to whisper.cpp. When a
user selected a non-English language those hardcoded English headers could
bias the Whisper decoder toward English output, causing incorrect
transcription.

Replaces the two textareas with a single freeform textarea and adds an
amber-coloured warning that the prompt should be written in the same
language as the audio. A migrateCustomPrompt() helper strips the old
section headers from any prompts saved under the previous format.
All seven locale files updated accordingly.

https://claude.ai/code/session_01UA7v4mTJvEWYYHepQiyi59