### PR TITLE
Fix: Auto-import caption template after switching Resolve projects

### DIFF
--- a/AutoSubs-App/src-tauri/resources/modules/autosubs_core.lua
+++ b/AutoSubs-App/src-tauri/resources/modules/autosubs_core.lua
@@ -93,6 +93,22 @@ local mediaPool = project:GetMediaPool()
 
 local ANIMATED_CAPTION = "AutoSubs Caption"
 local defaultTemplateImportAttempted = false
+local lastProjectId = project:GetUniqueId()
+
+-- Refresh the cached project / mediaPool references and detect project
+-- switches. When the user opens a different Resolve project the old
+-- mediaPool no longer contains the AutoSubs Caption template, so we
+-- must reset the one-shot import guard so get_templates() will try
+-- the import again.
+local function refresh_project()
+    project = projectManager:GetCurrentProject()
+    mediaPool = project:GetMediaPool()
+    local currentId = project:GetUniqueId()
+    if currentId ~= lastProjectId then
+        defaultTemplateImportAttempted = false
+        lastProjectId = currentId
+    end
+end
 
 local STYLE_INDEX = {
     Fill = 1,
@@ -306,9 +322,8 @@ get_template_item = function(folder, templateName)
 end
 
 function GetTimelineInfo()
-    -- Get project and media pool
-    project = projectManager:GetCurrentProject()
-    mediaPool = project:GetMediaPool()
+    -- Get project and media pool (resets template-import flag on project switch)
+    refresh_project()
 
     -- Get timeline info
     local timelineInfo = {}
@@ -335,8 +350,7 @@ function GetTimelineInfo()
 end
 
 function GetTemplates()
-    project = projectManager:GetCurrentProject()
-    mediaPool = project:GetMediaPool()
+    refresh_project()
     return get_templates()
 end
 
@@ -947,6 +961,13 @@ local function get_template(rootFolder, templateName)
     if templateName ~= nil and templateName ~= "" then
         templateItem = get_template_item(rootFolder, templateName)
     end
+    -- If the template wasn't found, trigger get_templates() which will
+    -- auto-import the default caption-bin.drb if it hasn't been tried for
+    -- this project yet, then retry the lookup.
+    if not templateItem and templateName ~= nil and templateName ~= "" then
+        get_templates()
+        templateItem = get_template_item(rootFolder, templateName)
+    end
     if not templateItem then
         templateItem = get_template_item(rootFolder, "Default Template")
     end
@@ -1203,6 +1224,7 @@ end
 -- presetSettings: optional opaque table of AutoSubs Caption macro input values
 -- (captured via StartPresetEdit/CapturePresetSettings). Ignored for non-animated templates.
 function AddSubtitles(filePath, trackIndex, templateName, conflictMode, presetSettings)
+    refresh_project()
     resolve:OpenPage("edit")
 
     local data, loadErr = load_subtitle_data(filePath)
@@ -1365,6 +1387,7 @@ end
 -- `language` (optional): ISO code of the transcript this preview represents,
 -- used for language-aware font fallback on the AutoSubs Caption macro.
 function GeneratePreview(speaker, templateName, presetSettings, exportDir, language)
+    refresh_project()
     local timeline = project:GetCurrentTimeline()
     if not timeline then
         return make_error("Failed to generate preview", "No active timeline in Resolve")
@@ -1373,6 +1396,11 @@ function GeneratePreview(speaker, templateName, presetSettings, exportDir, langu
 
     -- Resolve the template item
     local templateItem = get_template_item(rootFolder, templateName)
+    if not templateItem then
+        -- Template missing — trigger auto-import and retry
+        get_templates()
+        templateItem = get_template_item(rootFolder, templateName)
+    end
     if not templateItem then
         return make_error("Failed to generate preview",
             "Could not find subtitle template '" .. tostring(templateName) .. "' in media pool")
@@ -1480,6 +1508,7 @@ function StartPresetEdit(initialSettings)
         return { error = "A preset edit is already in progress" }
     end
 
+    refresh_project()
     local timeline = project:GetCurrentTimeline()
     if not timeline then
         return { error = "No active timeline" }
@@ -1487,6 +1516,11 @@ function StartPresetEdit(initialSettings)
 
     local rootFolder = mediaPool:GetRootFolder()
     local templateItem = get_template_item(rootFolder, ANIMATED_CAPTION)
+    if not templateItem then
+        -- Template missing — trigger auto-import and retry
+        get_templates()
+        templateItem = get_template_item(rootFolder, ANIMATED_CAPTION)
+    end
     if not templateItem then
         return { error = "Could not find '" .. ANIMATED_CAPTION .. "' template in media pool" }
     end


### PR DESCRIPTION
Related to #575

### Context
I ran into this bug while working on a multicam editing workflow where I generate Resolve project files programmatically via the DaVinci API for faster turnaround. Because I'm frequently switching between these generated projects, AutoSubs would consistently fail when trying to add subtitles to the timeline after a project switch:
`Could not find subtitle template 'AutoSubs Caption' in media pool`
The only workaround was to manually re-run the AutoSubs script from Workspace → Scripts every time I switched projects, which completely broke my flow.

### Root Cause
The Lua server (autosubs_core.lua) caches the project and mediaPool references at module load time and uses a one-shot defaultTemplateImportAttempted flag to guard the auto-import of caption-bin.drb. Once the template has been imported (or attempted) in one project, the flag stays true for the entire session. So when you switch to a different project whose media pool doesn't have the template yet, the import never fires again.

Some functions like `GetTimelineInfo()` and `GetTemplates()` already refreshed project/mediaPool inline, but the critical entry points that actually place subtitles (`AddSubtitles()`, `GeneratePreview()`, and `StartPresetEdit()`) did not. And none of them had any awareness of whether the project had changed.

### Changes
All changes are confined to autosubs_core.lua (Resolve-only, no impact on Premiere/AE):

**1. Project change detection via refresh_project()**
Added a small helper that refreshes the cached project/mediaPool references and compares project:GetUniqueId() against a stored lastProjectId. When a project switch is detected, defaultTemplateImportAttempted is reset so the auto-import can run again for the new project. lastProjectId is initialized at module load, so the first call doesn't trigger a false positive.

**2. Centralized project refresh**
Replaced the inline project = projectManager:GetCurrentProject() / mediaPool = project:GetMediaPool() calls in GetTimelineInfo() and GetTemplates() with calls to refresh_project(). Same behavior, but now with project-change awareness.

**3. Added refresh_project() to all critical entry points**
`AddSubtitles()`, `GeneratePreview()`, and `StartPresetEdit()` now call `refresh_project()` at the top, ensuring stale references are refreshed before any media pool lookups.

**4. Auto-import retry on template miss**
If a template lookup fails in `get_template()`, `GeneratePreview()`, or `StartPresetEdit()`, the code now calls `get_templates()` (which handles the caption-bin.drb import) and retries the lookup before giving up. This is safe because `get_templates()` immediately sets defaultTemplateImportAttempted = true, preventing any double-import on subsequent calls.

### Scope
**DaVinci Resolve only**: autosubs_core.lua runs exclusively inside Resolve's LuaJIT environment. Adobe Premiere/After Effects uses a completely separate WebSocket-based integration path that doesn't touch this file.

**Non-destructive**: no existing behavior is changed for same-project sessions. The project ID comparison is a no-op when you stay in the same project.


💛 Thanks for your work, AutoSubs saves me a great deal of time. Hope this makes a useful contribution.