### PR TITLE
refactor(settings): migrate SettingsContext to Zustand store

### DIFF
--- a/AutoSubs-App/package-lock.json
+++ b/AutoSubs-App/package-lock.json
@@ -82,7 +82,8 @@
         "tailwind-merge": "^2.5.3",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^1.1.2",
-        "zod": "^3.25.76"
+        "zod": "^3.25.76",
+        "zustand": "^5.0.14"
       },
       "devDependencies": {
         "@tauri-apps/api": "^2.7.0",
@@ -8687,6 +8688,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/AutoSubs-App/package.json
+++ b/AutoSubs-App/package.json
@@ -101,7 +101,8 @@
     "tailwind-merge": "^2.5.3",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.2",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "zustand": "^5.0.14"
   },
   "devDependencies": {
     "@tauri-apps/api": "^2.7.0",

--- a/AutoSubs-App/src/App.tsx
+++ b/AutoSubs-App/src/App.tsx
@@ -10,7 +10,7 @@ import { TooltipProvider } from "@/components/ui/tooltip"
 import { GettingStartedOverlay } from "@/components/dialogs/getting-started-overlay"
 import { OnboardingTour } from "@/components/dialogs/onboarding-tour"
 import { WhatsNewDialog } from "@/components/dialogs/whats-new-dialog"
-import { useSettings } from "@/contexts/SettingsContext"
+import { useSettingsStore } from "@/stores/settings-store"
 import { getVersion } from "@tauri-apps/api/app"
 import { EditorWorkspaceProviders } from "@/contexts/GlobalProvider"
 import { useSubtitleDocument } from "@/contexts/SubtitleDocumentContext"
@@ -67,7 +67,10 @@ function AppContentBody() {
   >([])
   const [hasLoadedTranscriptDocuments, setHasLoadedTranscriptDocuments] =
     React.useState(false)
-  const { settings, isHydrated } = useSettings()
+  const onboardingCompleted = useSettingsStore((s) => s.onboardingCompleted)
+  const tourCompleted = useSettingsStore((s) => s.tourCompleted)
+  const lastSeenVersion = useSettingsStore((s) => s.lastSeenVersion)
+  const isHydrated = useSettingsStore((s) => s.isHydrated)
   const { subtitles } = useSubtitleDocument()
   const [currentVersion, setCurrentVersion] = React.useState<string>("")
   const isMobile = useIsMobile()
@@ -104,17 +107,17 @@ function AppContentBody() {
   }, [loadTranscriptDocuments])
 
   // Priority gating: only show one onboarding-style dialog at a time.
-  const showGettingStarted = isHydrated && !settings.onboardingCompleted
+  const showGettingStarted = isHydrated && !onboardingCompleted
   const showWhatsNew =
     isHydrated &&
-    settings.onboardingCompleted &&
+    onboardingCompleted &&
     !!currentVersion &&
-    settings.lastSeenVersion !== currentVersion
+    lastSeenVersion !== currentVersion
 
   const showTour =
     isHydrated &&
-    settings.onboardingCompleted &&
-    settings.tourCompleted === false &&
+    onboardingCompleted &&
+    tourCompleted === false &&
     !showWhatsNew
 
   const handleCloseSubtitleViewer = React.useCallback(() => {

--- a/AutoSubs-App/src/censor/merge.ts
+++ b/AutoSubs-App/src/censor/merge.ts
@@ -1,7 +1,9 @@
 import { Settings } from '@/types';
 import { BUILT_IN_CENSOR_LISTS } from './built-in-lists';
 
-export function getActiveCensorWords(settings: Settings): string[] {
+export function getActiveCensorWords(
+    settings: Pick<Settings, 'enableCensor' | 'censoredWords' | 'activeCensorLists'>,
+): string[] {
     if (!settings.enableCensor) return [];
 
     const custom = settings.censoredWords ?? [];

--- a/AutoSubs-App/src/components/dialogs/add-to-timeline-dialog.tsx
+++ b/AutoSubs-App/src/components/dialogs/add-to-timeline-dialog.tsx
@@ -19,7 +19,7 @@ import { useTranslation } from "react-i18next"
 import { Settings, Speaker, Template, TimelineInfo } from "@/types"
 import { useSubtitleDocument } from "@/contexts/SubtitleDocumentContext"
 import { usePresets, DEFAULT_PRESET_ID } from "@/contexts/PresetsContext"
-import { useSettings } from "@/contexts/SettingsContext"
+import { useSettingsStore } from "@/stores/settings-store"
 import { SpeakerSettings } from "@/components/common/speaker-settings"
 import {
     ANIMATED_CAPTION_TEMPLATE,
@@ -80,7 +80,7 @@ export function AddToTimelineDialog({
     const isAdobe = selectedIntegration === "premiere" || selectedIntegration === "aftereffects"
     const { t } = useTranslation()
     const { speakers, updateSpeakers, currentSubtitleDocumentFilename } = useSubtitleDocument()
-    const { updateSetting } = useSettings()
+    const updateSetting = useSettingsStore((s) => s.updateSetting)
     const {
         presets,
         getPreset,

--- a/AutoSubs-App/src/components/dialogs/add-to-timeline-dialog.tsx
+++ b/AutoSubs-App/src/components/dialogs/add-to-timeline-dialog.tsx
@@ -16,9 +16,10 @@ import {
     Palette,
 } from "lucide-react"
 import { useTranslation } from "react-i18next"
-import { Settings, Speaker, Template, TimelineInfo } from "@/types"
+import { Speaker, Template, TimelineInfo } from "@/types"
 import { useSubtitleDocument } from "@/contexts/SubtitleDocumentContext"
 import { usePresets, DEFAULT_PRESET_ID } from "@/contexts/PresetsContext"
+import { useShallow } from "zustand/react/shallow"
 import { useSettingsStore } from "@/stores/settings-store"
 import { SpeakerSettings } from "@/components/common/speaker-settings"
 import {
@@ -44,7 +45,6 @@ interface Selection {
 
 interface AddToTimelineDialogProps {
     children: React.ReactNode
-    settings: Settings
     timelineInfo: TimelineInfo
     templates: Template[]
     templatesLoading: boolean
@@ -67,7 +67,6 @@ const STEPS = [
 
 export function AddToTimelineDialog({
     children,
-    settings,
     timelineInfo,
     templates,
     templatesLoading,
@@ -80,7 +79,16 @@ export function AddToTimelineDialog({
     const isAdobe = selectedIntegration === "premiere" || selectedIntegration === "aftereffects"
     const { t } = useTranslation()
     const { speakers, updateSpeakers, currentSubtitleDocumentFilename } = useSubtitleDocument()
-    const updateSetting = useSettingsStore((s) => s.updateSetting)
+    const { selectedTemplate, presetId, selectedOutputTrack, captionMode, updateSetting } =
+        useSettingsStore(
+            useShallow((s) => ({
+                selectedTemplate: s.selectedTemplate,
+                presetId: s.presetId,
+                selectedOutputTrack: s.selectedOutputTrack,
+                captionMode: s.captionMode,
+                updateSetting: s.updateSetting,
+            })),
+        )
     const {
         presets,
         getPreset,
@@ -95,9 +103,9 @@ export function AddToTimelineDialog({
     const [currentStep, setCurrentStep] = React.useState(0)
     const [selection, setSelection] = React.useState<Selection>(() => ({
         mode: "regular",
-        templateValue: settings.selectedTemplate.value,
-        presetId: settings.presetId || DEFAULT_PRESET_ID,
-        outputTrack: settings.selectedOutputTrack,
+        templateValue: selectedTemplate.value,
+        presetId: presetId || DEFAULT_PRESET_ID,
+        outputTrack: selectedOutputTrack,
     }))
     const [localSpeakers, setLocalSpeakers] = React.useState<Speaker[]>(speakers)
     const [isSubmitting, setIsSubmitting] = React.useState(false)
@@ -122,9 +130,9 @@ export function AddToTimelineDialog({
 
     // Keep refs so the open-effect can read the latest values without being
     // re-triggered every time settings/speakers get a new object reference.
-    const settingsRef = React.useRef(settings)
+    const settingsRef = React.useRef({ selectedTemplate, presetId, selectedOutputTrack, captionMode })
     const speakersRef = React.useRef(speakers)
-    settingsRef.current = settings
+    settingsRef.current = { selectedTemplate, presetId, selectedOutputTrack, captionMode }
     speakersRef.current = speakers
 
     // Re-hydrate from settings whenever the dialog opens; a fresh session should

--- a/AutoSubs-App/src/components/dialogs/caption-style/template-selection.tsx
+++ b/AutoSubs-App/src/components/dialogs/caption-style/template-selection.tsx
@@ -7,7 +7,7 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/animated-tabs"
 import { useIntegration } from "@/contexts/IntegrationContext"
 import { DEFAULT_PRESET_ID, usePresets } from "@/contexts/PresetsContext"
-import { useSettings } from "@/contexts/SettingsContext"
+import { useSettingsStore } from "@/stores/settings-store"
 import { CaptionPreset, Template, TimelineInfo } from "@/types"
 import {
     AnimatedPresetActions,
@@ -225,7 +225,10 @@ export function CaptionTemplateSelectionDialog({
     timelineInfo,
 }: CaptionTemplateSelectionDialogProps) {
     const { t } = useTranslation()
-    const { settings, updateSetting } = useSettings()
+    const captionMode = useSettingsStore((s) => s.captionMode)
+    const selectedTemplate = useSettingsStore((s) => s.selectedTemplate)
+    const presetId = useSettingsStore((s) => s.presetId)
+    const updateSetting = useSettingsStore((s) => s.updateSetting)
     const {
         presets,
         getPreset,
@@ -236,9 +239,9 @@ export function CaptionTemplateSelectionDialog({
         exportPreset,
     } = usePresets()
     const [selection, setSelection] = React.useState<CaptionTemplateSelection>(() => ({
-        mode: settings.captionMode,
-        templateValue: settings.selectedTemplate.value,
-        presetId: settings.presetId || DEFAULT_PRESET_ID,
+        mode: captionMode,
+        templateValue: selectedTemplate.value,
+        presetId: presetId || DEFAULT_PRESET_ID,
     }))
     const [templateLoadError, setTemplateLoadError] = React.useState<string | null>(null)
     const [loadingTimedOut, setLoadingTimedOut] = React.useState(false)
@@ -250,9 +253,9 @@ export function CaptionTemplateSelectionDialog({
         setPrevHydrateKey(hydrateKey)
         if (open) {
             setSelection({
-                mode: settings.captionMode,
-                templateValue: settings.selectedTemplate.value,
-                presetId: settings.presetId || DEFAULT_PRESET_ID,
+                mode: captionMode,
+                templateValue: selectedTemplate.value,
+                presetId: presetId || DEFAULT_PRESET_ID,
             })
             setTemplateLoadError(null)
             setLoadingTimedOut(false)

--- a/AutoSubs-App/src/components/dialogs/getting-started-overlay.tsx
+++ b/AutoSubs-App/src/components/dialogs/getting-started-overlay.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { getVersion } from "@tauri-apps/api/app";
 
-import { useSettings } from "@/contexts/SettingsContext";
+import { useSettingsStore } from "@/stores/settings-store";
 import { useResolve } from "@/contexts/ResolveContext";
 import { useAdobe } from "@/contexts/AdobeContext";
 import { initI18n, normalizeUiLanguage } from "@/i18n";
@@ -26,25 +26,28 @@ import { Globe, Check, MoveRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export function GettingStartedOverlay() {
-  const { settings, updateSetting, isHydrated } = useSettings();
+  const uiLanguage = useSettingsStore((s) => s.uiLanguage);
+  const onboardingCompleted = useSettingsStore((s) => s.onboardingCompleted);
+  const updateSetting = useSettingsStore((s) => s.updateSetting);
+  const isHydrated = useSettingsStore((s) => s.isHydrated);
   const { t } = useTranslation();
   const { timelineInfo: resolveTimeline } = useResolve();
   const { isConnected: isPremiereConnected } = useAdobe();
   
   const isResolveConnected = resolveTimeline.timelineId !== "";
   const isIntegrationConnected = isResolveConnected || isPremiereConnected;
-  const shouldShow = isHydrated && !settings.onboardingCompleted;
+  const shouldShow = isHydrated && !onboardingCompleted;
 
   const [selection, setSelection] = React.useState<string>(() => {
-    return normalizeUiLanguage(settings.uiLanguage);
+    return normalizeUiLanguage(uiLanguage);
   });
   const [open, setOpen] = React.useState(false);
 
   React.useEffect(() => {
     if (shouldShow) {
-      setSelection(normalizeUiLanguage(settings.uiLanguage));
+      setSelection(normalizeUiLanguage(uiLanguage));
     }
-  }, [shouldShow, settings.uiLanguage]);
+  }, [shouldShow, uiLanguage]);
 
   const handleLanguageSelect = (value: string) => {
     setSelection(value);

--- a/AutoSubs-App/src/components/dialogs/onboarding-tour.tsx
+++ b/AutoSubs-App/src/components/dialogs/onboarding-tour.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Joyride, STATUS } from "react-joyride";
 import type { Step, EventData, TooltipRenderProps } from "react-joyride";
 import { useTranslation } from "react-i18next";
-import { useSettings } from "@/contexts/SettingsContext";
+import { useSettingsStore } from "@/stores/settings-store";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 
@@ -85,7 +85,7 @@ function TourTooltip({
 
 export function OnboardingTour() {
   const { t } = useTranslation();
-  const { updateSetting } = useSettings();
+  const updateSetting = useSettingsStore((s) => s.updateSetting);
   const [run, setRun] = React.useState(true);
 
   const steps: Step[] = React.useMemo(

--- a/AutoSubs-App/src/components/dialogs/settings-dialog.tsx
+++ b/AutoSubs-App/src/components/dialogs/settings-dialog.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Gauge, Clock, GraduationCap, Terminal } from "lucide-react";
 import { DeleteIcon, type DeleteIconHandle } from "@/components/ui/icons/delete";
-import { useSettings } from "@/contexts/SettingsContext";
+import { useSettingsStore } from "@/stores/settings-store";
 import { ask, message } from "@tauri-apps/plugin-dialog";
 import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
@@ -35,7 +35,11 @@ interface SettingsDialogProps {
 }
 
 export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
-  const { settings, updateSetting, resetSettings } = useSettings();
+  const uiLanguage = useSettingsStore((s) => s.uiLanguage);
+  const enableGpu = useSettingsStore((s) => s.enableGpu);
+  const enableDTW = useSettingsStore((s) => s.enableDTW);
+  const updateSetting = useSettingsStore((s) => s.updateSetting);
+  const resetSettings = useSettingsStore((s) => s.resetSettings);
   const { t, i18n } = useTranslation();
   const deleteIconRef = useRef<DeleteIconHandle>(null);
 
@@ -137,7 +141,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
 
                     <ItemActions className="w-[170px] shrink-0 justify-end">
                       <Select
-                        value={normalizeUiLanguage(settings.uiLanguage)}
+                        value={normalizeUiLanguage(uiLanguage)}
                         onValueChange={(value) => {
                           const normalized = normalizeUiLanguage(value);
                           updateSetting("uiLanguage", normalized);
@@ -201,7 +205,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                     </ItemContent>
                     <ItemActions>
                       <Switch
-                        checked={settings.enableGpu}
+                        checked={enableGpu}
                         onCheckedChange={(checked) => updateSetting("enableGpu", checked)}
                       />
                     </ItemActions>
@@ -221,7 +225,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                     </ItemContent>
                     <ItemActions>
                       <Switch
-                        checked={settings.enableDTW}
+                        checked={enableDTW}
                         onCheckedChange={(checked) => updateSetting("enableDTW", checked)}
                       />
                     </ItemActions>

--- a/AutoSubs-App/src/components/dialogs/whats-new-dialog.tsx
+++ b/AutoSubs-App/src/components/dialogs/whats-new-dialog.tsx
@@ -5,7 +5,7 @@ import { getVersion } from "@tauri-apps/api/app";
 import { open as openExternal } from "@tauri-apps/plugin-shell";
 import { useTranslation } from "react-i18next";
 
-import { useSettings } from "@/contexts/SettingsContext";
+import { useSettingsStore } from "@/stores/settings-store";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
@@ -35,7 +35,10 @@ interface ReleaseInfo {
 
 export function WhatsNewDialog() {
   const { t } = useTranslation();
-  const { settings, updateSetting, isHydrated } = useSettings();
+  const onboardingCompleted = useSettingsStore((s) => s.onboardingCompleted);
+  const lastSeenVersion = useSettingsStore((s) => s.lastSeenVersion);
+  const updateSetting = useSettingsStore((s) => s.updateSetting);
+  const isHydrated = useSettingsStore((s) => s.isHydrated);
 
   const [currentVersion, setCurrentVersion] = React.useState<string>("");
   const [release, setRelease] = React.useState<ReleaseInfo | null>(null);
@@ -49,9 +52,9 @@ export function WhatsNewDialog() {
   // - Show whenever stored lastSeenVersion differs from running version.
   const shouldShow =
     isHydrated &&
-    settings.onboardingCompleted &&
+    onboardingCompleted &&
     !!currentVersion &&
-    settings.lastSeenVersion !== currentVersion;
+    lastSeenVersion !== currentVersion;
 
   React.useEffect(() => {
     if (shouldShow) {
@@ -149,7 +152,7 @@ export function WhatsNewDialog() {
           )}
         </DialogHeader>
 
-        {(!!settings.lastSeenVersion || showResolveRestartNotice) && (
+        {(!!lastSeenVersion || showResolveRestartNotice) && (
           <Alert className="border-blue-200 bg-blue-50 text-blue-950 dark:border-blue-900 dark:bg-blue-950/40 dark:text-blue-100">
             <Server className="size-4" />
             <AlertTitle>

--- a/AutoSubs-App/src/components/processing/completion-step-item.tsx
+++ b/AutoSubs-App/src/components/processing/completion-step-item.tsx
@@ -9,8 +9,9 @@ import {
 import { Download, FileText, Plus, VolumeX } from "lucide-react"
 import { AddToTimelineDialog } from "@/components/dialogs/add-to-timeline-dialog"
 import { ImportExportPopover } from "@/components/common/import-export-popover"
-import { Settings, TimelineInfo } from "@/types"
+import { TimelineInfo } from "@/types"
 import { useResolve } from "@/contexts/ResolveContext"
+import { useSettingsStore } from "@/stores/settings-store"
 import { useSubtitleDocument } from "@/contexts/SubtitleDocumentContext"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { useTranslation } from "react-i18next"
@@ -20,7 +21,6 @@ export interface CompletionStepProps {
     onAddToTimeline: (selectedOutputTrack: string, selectedTemplate: string, presetSettings?: Record<string, unknown>) => Promise<void>;
     onViewSubtitles?: () => void;
     isSubtitleViewerOpen?: boolean;
-    settings: Settings;
     timelineInfo: TimelineInfo;
     selectedIntegration?: "davinci" | "premiere" | "aftereffects";
 }
@@ -29,7 +29,6 @@ export function CompletionStepItem({
     onAddToTimeline,
     onViewSubtitles,
     isSubtitleViewerOpen = false,
-    settings,
     timelineInfo,
     selectedIntegration
 }: CompletionStepProps) {
@@ -88,7 +87,7 @@ export function CompletionStepItem({
                             )}
                             {(!isResolveConnected || !isMobile) && (
                                 <ImportExportPopover
-                                    onImport={() => importSubtitles(settings, null, "")}
+                                    onImport={() => importSubtitles(useSettingsStore.getState(), null, "")}
                                     onExport={(format) => exportSubtitlesAs(format, subtitles, speakers)}
                                     hasSubtitles={hasSubtitles}
                                     trigger={
@@ -105,7 +104,6 @@ export function CompletionStepItem({
                             )}
                             {(isResolveConnected || isAdobeConnected) && (
                                 <AddToTimelineDialog
-                                    settings={settings}
                                     timelineInfo={timelineInfo}
                                     templates={isAdobe ? [] : resolveTemplates}
                                     templatesLoading={!isAdobe && resolveTemplatesLoading}

--- a/AutoSubs-App/src/components/processing/processing-step-item.tsx
+++ b/AutoSubs-App/src/components/processing/processing-step-item.tsx
@@ -8,7 +8,7 @@ import { Spinner } from "@/components/ui/spinner"
 import { CircleX, CircleCheck } from "lucide-react"
 import { CompletionStepItem } from "./completion-step-item"
 import { SegmentPreview } from "@/components/processing/segment-preview"
-import { Settings, TimelineInfo } from "@/types"
+import { TimelineInfo } from "@/types"
 
 export interface ProcessingStepProps {
     title: string;
@@ -23,7 +23,6 @@ export interface ProcessingStepProps {
     onViewSubtitles?: () => void;
     isSubtitleViewerOpen?: boolean;
     livePreviewSegments?: any[];
-    settings?: Settings;
     timelineInfo?: TimelineInfo;
     selectedIntegration?: "davinci" | "premiere" | "aftereffects";
 }
@@ -41,13 +40,12 @@ export function ProcessingStepItem({
     onViewSubtitles,
     isSubtitleViewerOpen = false,
     livePreviewSegments = [],
-    settings,
     timelineInfo,
     selectedIntegration
 }: ProcessingStepProps) {
     // If this is the completion step, render the special completion component
-    if (id === 'Complete' && onExportToFile && onAddToTimeline && settings && timelineInfo) {
-        return <CompletionStepItem onExportToFile={onExportToFile} onAddToTimeline={onAddToTimeline} onViewSubtitles={onViewSubtitles} isSubtitleViewerOpen={isSubtitleViewerOpen} settings={settings} timelineInfo={timelineInfo} selectedIntegration={selectedIntegration} />;
+    if (id === 'Complete' && onExportToFile && onAddToTimeline && timelineInfo) {
+        return <CompletionStepItem onExportToFile={onExportToFile} onAddToTimeline={onAddToTimeline} onViewSubtitles={onViewSubtitles} isSubtitleViewerOpen={isSubtitleViewerOpen} timelineInfo={timelineInfo} selectedIntegration={selectedIntegration} />;
     }
 
     return (

--- a/AutoSubs-App/src/components/settings/diarize-selector.tsx
+++ b/AutoSubs-App/src/components/settings/diarize-selector.tsx
@@ -1,12 +1,14 @@
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Slider } from "@/components/ui/slider";
-import { useSettings } from "@/contexts/SettingsContext";
+import { useSettingsStore } from "@/stores/settings-store";
 import { useTranslation } from "react-i18next";
 
 export function SpeakerSelector() {
   const { t } = useTranslation();
-  const { settings, updateSetting } = useSettings();
+  const enableDiarize = useSettingsStore((s) => s.enableDiarize);
+  const maxSpeakers = useSettingsStore((s) => s.maxSpeakers);
+  const updateSetting = useSettingsStore((s) => s.updateSetting);
 
   // 0 = Auto, then 2-10 speakers (skips 1)
   const speakerValues = [0, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -40,13 +42,13 @@ export function SpeakerSelector() {
 
             <span
               className={`text-sm font-medium ${
-                settings.enableDiarize ? "text-primary" : "text-red-500"
+                enableDiarize ? "text-primary" : "text-red-500"
               }`}
             >
-              {settings.enableDiarize
-                ? settings.maxSpeakers === null
+              {enableDiarize
+                ? maxSpeakers === null
                   ? t("actionBar.common.auto")
-                  : settings.maxSpeakers
+                  : maxSpeakers
                 : t("actionBar.speakers.disabled")}
             </span>
           </div>
@@ -54,12 +56,12 @@ export function SpeakerSelector() {
           <Slider
             value={[
               sliderIndexFor(
-                settings.enableDiarize ? (settings.maxSpeakers ?? 0) : 0,
+                enableDiarize ? (maxSpeakers ?? 0) : 0,
               ),
             ]}
             onValueChange={([index]: [number]) => {
               // Dragging the slider automatically enables diarization
-              if (!settings.enableDiarize) {
+              if (!enableDiarize) {
                 updateSetting("enableDiarize", true);
               }
 
@@ -94,7 +96,7 @@ export function SpeakerSelector() {
             </div>
 
             <Switch
-              checked={settings.enableDiarize}
+              checked={enableDiarize}
               onCheckedChange={(checked: boolean) =>
                 updateSetting("enableDiarize", checked)
               }

--- a/AutoSubs-App/src/components/settings/language-selector.tsx
+++ b/AutoSubs-App/src/components/settings/language-selector.tsx
@@ -3,7 +3,7 @@ import { Globe, Languages, Check, Cpu, Cloud } from "lucide-react"
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
 import { Switch } from "@/components/ui/switch"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
-import { useSettings } from "@/contexts/SettingsContext"
+import { useSettingsStore } from "@/stores/settings-store"
 import { languages, translateLanguages, getTranslationMethod } from "@/lib/languages"
 import { models, modelSupportsLanguage } from "@/lib/models"
 import { cn } from "@/lib/utils"
@@ -12,9 +12,13 @@ import { useTranslation } from "react-i18next"
 
 export function LanguageSelector() {
     const { t } = useTranslation()
-    const { settings, updateSetting } = useSettings()
+    const model = useSettingsStore((s) => s.model)
+    const language = useSettingsStore((s) => s.language)
+    const targetLanguage = useSettingsStore((s) => s.targetLanguage)
+    const translate = useSettingsStore((s) => s.translate)
+    const updateSetting = useSettingsStore((s) => s.updateSetting)
     const [languageTab, setLanguageTab] = React.useState<'source' | 'translate'>('source')
-    const currentModel = models[settings.model]
+    const currentModel = models[model]
     const sourceInputRef = React.useRef<HTMLInputElement>(null)
     const translateInputRef = React.useRef<HTMLInputElement>(null)
 
@@ -40,16 +44,16 @@ export function LanguageSelector() {
                         <CommandGroup>
                             {languages
                                 .slice()
-                                .map((language) => {
+                                .map((lang) => {
                                     const supported = currentModel
-                                        ? modelSupportsLanguage(currentModel, language.value)
+                                        ? modelSupportsLanguage(currentModel, lang.value)
                                         : true
                                     return (
                                     <CommandItem
-                                        value={language.label}
-                                        key={language.value}
+                                        value={lang.label}
+                                        key={lang.value}
                                         onSelect={() => {
-                                            updateSetting("language", language.value);
+                                            updateSetting("language", lang.value);
                                         }}
                                         className={cn(
                                             !supported && "opacity-40 pointer-events-auto"
@@ -58,12 +62,12 @@ export function LanguageSelector() {
                                         <Check
                                             className={cn(
                                                 "mr-2 size-4",
-                                                language.value === settings.language
+                                                lang.value === language
                                                     ? "opacity-100"
                                                     : "opacity-0"
                                             )}
                                         />
-                                        {language.label}
+                                        {lang.label}
                                     </CommandItem>
                                     )
                                 })}
@@ -77,7 +81,7 @@ export function LanguageSelector() {
                     <div className="relative">
                         <CommandInput ref={translateInputRef} placeholder={t("actionBar.language.searchTargetPlaceholder")} className="border-0 focus-visible:ring-0 px-0 pr-12" />
                         <Switch
-                            checked={settings.translate}
+                            checked={translate}
                             onCheckedChange={(checked: boolean) => updateSetting("translate", checked)}
                             className="absolute right-2 top-1/2 -translate-y-1/2"
                         />
@@ -85,23 +89,23 @@ export function LanguageSelector() {
                     <CommandList>
                         <CommandEmpty>{t("actionBar.language.noLanguageFound")}</CommandEmpty>
                         <CommandGroup>
-                            {translateLanguages.map((language) => {
+                            {translateLanguages.map((lang) => {
                                 const method = currentModel
-                                    ? getTranslationMethod(currentModel.engine, settings.language, language.value)
+                                    ? getTranslationMethod(currentModel.engine, language, lang.value)
                                     : "google"
                                 // Disable selecting the source language as the
                                 // translation target — translating a language
                                 // to itself is a no-op and almost always a mistake.
-                                const isSourceLang = language.value === settings.language
+                                const isSourceLang = lang.value === language
                                 return (
                                 <CommandItem
-                                    value={language.label}
-                                    key={language.value}
+                                    value={lang.label}
+                                    key={lang.value}
                                     disabled={isSourceLang}
                                     onSelect={() => {
                                         if (isSourceLang) return
-                                        updateSetting("targetLanguage", language.value);
-                                        if (!settings.translate) {
+                                        updateSetting("targetLanguage", lang.value);
+                                        if (!translate) {
                                             updateSetting("translate", true);
                                         }
                                     }}
@@ -109,12 +113,12 @@ export function LanguageSelector() {
                                     <Check
                                         className={cn(
                                             "mr-2 size-4",
-                                            language.value === settings.targetLanguage
+                                            lang.value === targetLanguage
                                                 ? "opacity-100"
                                                 : "opacity-0"
                                         )}
                                     />
-                                    {language.label}
+                                    {lang.label}
                                     {method === "native" ? (
                                         <Tooltip>
                                             <TooltipTrigger asChild>
@@ -159,7 +163,7 @@ export function LanguageSelector() {
                 <TabsTrigger value="translate" className="flex-1 gap-1.5 text-xs py-1.5">
                     <Languages className="size-3.5" />
                     {t("actionBar.language.translate")}
-                    {settings.translate && (
+                    {translate && (
                         <span className="ml-0.5 size-1.5 rounded-full bg-primary" />
                     )}
                 </TabsTrigger>

--- a/AutoSubs-App/src/components/settings/text-formatting-panel.tsx
+++ b/AutoSubs-App/src/components/settings/text-formatting-panel.tsx
@@ -63,6 +63,13 @@ export function TextFormattingPanel({
     const [openCensorDialog, setOpenCensorDialog] = React.useState(false)
     const [newCensoredWord, setNewCensoredWord] = React.useState("")
 
+    // Derive the active censor word count from the subscribed fields so it
+    // stays reactive without a non-reactive getState() call during render.
+    const censorWordCount = React.useMemo(
+        () => getActiveCensorWords({ enableCensor, censoredWords, activeCensorLists }).length,
+        [enableCensor, censoredWords, activeCensorLists],
+    )
+
     return (
         <div>
             <div className="p-4 space-y-3">
@@ -161,7 +168,7 @@ export function TextFormattingPanel({
                     <div className="space-y-0.5">
                         <Label className="text-sm font-medium">{t("actionBar.censor.title")}</Label>
                         <p className="text-xs text-muted-foreground">
-                            {t("actionBar.censor.wordCount", { count: getActiveCensorWords(useSettingsStore.getState()).length })}
+                            {t("actionBar.censor.wordCount", { count: censorWordCount })}
                             {!enableCensor ? ` · ${t("actionBar.common.off")}` : ""}
                         </p>
                     </div>

--- a/AutoSubs-App/src/components/settings/text-formatting-panel.tsx
+++ b/AutoSubs-App/src/components/settings/text-formatting-panel.tsx
@@ -17,7 +17,8 @@ import {
     DialogTitle,
     DialogTrigger,
 } from "@/components/ui/dialog"
-import { useSettings } from "@/contexts/SettingsContext"
+import { useShallow } from "zustand/react/shallow"
+import { useSettingsStore } from "@/stores/settings-store"
 import { useTranslation } from "react-i18next"
 import { BUILT_IN_CENSOR_LISTS } from "@/censor/built-in-lists"
 import { getActiveCensorWords } from "@/censor/merge"
@@ -37,7 +38,28 @@ export function TextFormattingPanel({
     applyDisabled = false,
 }: TextFormattingPanelProps) {
     const { t } = useTranslation()
-    const { settings, updateSetting } = useSettings()
+    const {
+        textDensity,
+        customMaxCharsPerLine,
+        maxLinesPerSubtitle,
+        textCase,
+        removePunctuation,
+        enableCensor,
+        activeCensorLists,
+        censoredWords,
+    } = useSettingsStore(
+        useShallow((s) => ({
+            textDensity: s.textDensity,
+            customMaxCharsPerLine: s.customMaxCharsPerLine,
+            maxLinesPerSubtitle: s.maxLinesPerSubtitle,
+            textCase: s.textCase,
+            removePunctuation: s.removePunctuation,
+            enableCensor: s.enableCensor,
+            activeCensorLists: s.activeCensorLists,
+            censoredWords: s.censoredWords,
+        })),
+    )
+    const updateSetting = useSettingsStore((s) => s.updateSetting)
     const [openCensorDialog, setOpenCensorDialog] = React.useState(false)
     const [newCensoredWord, setNewCensoredWord] = React.useState("")
 
@@ -51,7 +73,7 @@ export function TextFormattingPanel({
                         <p className="text-xs text-muted-foreground">{t("actionBar.format.textDensityDescription")}</p>
                     </div>
                     <Select
-                        value={settings.textDensity}
+                        value={textDensity}
                         onValueChange={(value) => updateSetting("textDensity", value as "less" | "standard" | "more" | "single" | "custom")}
                     >
                         <SelectTrigger className="w-32">
@@ -68,7 +90,7 @@ export function TextFormattingPanel({
                 </div>
 
                 {/* Custom Max Chars Per Line (only shown when custom density is selected) */}
-                {settings.textDensity === "custom" && (
+                {textDensity === "custom" && (
                     <div className="flex items-center justify-between">
                         <div>
                             <Label className="text-sm font-medium">{t("actionBar.format.customCharsTitle")}</Label>
@@ -78,7 +100,7 @@ export function TextFormattingPanel({
                             type="number"
                             min="1"
                             max="100"
-                            value={settings.customMaxCharsPerLine}
+                            value={customMaxCharsPerLine}
                             onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateSetting("customMaxCharsPerLine", Number(e.target.value))}
                             className="w-20"
                         />
@@ -94,7 +116,7 @@ export function TextFormattingPanel({
                     <Input
                         type="number"
                         min="1"
-                        value={settings.maxLinesPerSubtitle}
+                        value={maxLinesPerSubtitle}
                         onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateSetting("maxLinesPerSubtitle", Number(e.target.value))}
                         className="w-20"
                     />
@@ -107,7 +129,7 @@ export function TextFormattingPanel({
                         <p className="text-xs text-muted-foreground">{t("actionBar.format.textCaseDescription")}</p>
                     </div>
                     <Select
-                        value={settings.textCase}
+                        value={textCase}
                         onValueChange={(val) => updateSetting("textCase", val as "none" | "uppercase" | "lowercase" | "titlecase")}
                     >
                         <SelectTrigger className="w-32">
@@ -129,7 +151,7 @@ export function TextFormattingPanel({
                         <p className="text-xs text-muted-foreground">{t("actionBar.format.removePunctuationDescription")}</p>
                     </div>
                     <Switch
-                        checked={settings.removePunctuation}
+                        checked={removePunctuation}
                         onCheckedChange={(checked: boolean) => updateSetting("removePunctuation", checked)}
                     />
                 </div>
@@ -139,8 +161,8 @@ export function TextFormattingPanel({
                     <div className="space-y-0.5">
                         <Label className="text-sm font-medium">{t("actionBar.censor.title")}</Label>
                         <p className="text-xs text-muted-foreground">
-                            {t("actionBar.censor.wordCount", { count: getActiveCensorWords(settings).length })}
-                            {!settings.enableCensor ? ` · ${t("actionBar.common.off")}` : ""}
+                            {t("actionBar.censor.wordCount", { count: getActiveCensorWords(useSettingsStore.getState()).length })}
+                            {!enableCensor ? ` · ${t("actionBar.common.off")}` : ""}
                         </p>
                     </div>
                     <div className="flex items-center gap-2">
@@ -168,7 +190,7 @@ export function TextFormattingPanel({
                                         <span className="text-sm font-medium">{t("actionBar.censor.lists")}</span>
                                         <div className="rounded-lg border bg-muted/20 p-3 space-y-2">
                                             {BUILT_IN_CENSOR_LISTS.map((list) => {
-                                                const isActive = (settings.activeCensorLists ?? []).includes(list.id);
+                                                const isActive = (activeCensorLists ?? []).includes(list.id);
                                                 return (
                                                     <div key={list.id} className="flex items-center justify-between">
                                                         <div className="flex-1 min-w-0 pr-2">
@@ -182,13 +204,13 @@ export function TextFormattingPanel({
                                                             <Switch
                                                                 checked={isActive}
                                                                 onCheckedChange={(checked: boolean) => {
-                                                                    const current = settings.activeCensorLists ?? [];
+                                                                    const current = activeCensorLists ?? [];
                                                                     if (checked) {
                                                                         updateSetting("activeCensorLists", [...current, list.id]);
                                                                     } else {
                                                                         updateSetting("activeCensorLists", current.filter((id: string) => id !== list.id));
                                                                     }
-                                                                    if (checked && !settings.enableCensor) {
+                                                                    if (checked && !enableCensor) {
                                                                         updateSetting("enableCensor", true);
                                                                     }
                                                                 }}
@@ -211,9 +233,9 @@ export function TextFormattingPanel({
                                             className="flex items-center gap-2 rounded-lg border bg-muted/30 pr-1"
                                             onSubmit={(e) => {
                                                 e.preventDefault();
-                                                if (!newCensoredWord.trim() || (settings.censoredWords || []).includes(newCensoredWord.trim())) return;
-                                                updateSetting("censoredWords", [...(settings.censoredWords || []), newCensoredWord.trim()]);
-                                                if (!settings.enableCensor) updateSetting("enableCensor", true);
+                                                if (!newCensoredWord.trim() || (censoredWords || []).includes(newCensoredWord.trim())) return;
+                                                updateSetting("censoredWords", [...(censoredWords || []), newCensoredWord.trim()]);
+                                                if (!enableCensor) updateSetting("enableCensor", true);
                                                 setNewCensoredWord("");
                                             }}
                                         >
@@ -226,26 +248,26 @@ export function TextFormattingPanel({
                                             <Button
                                                 type="submit"
                                                 size="sm"
-                                                disabled={!newCensoredWord.trim() || (settings.censoredWords || []).includes(newCensoredWord.trim())}
+                                                disabled={!newCensoredWord.trim() || (censoredWords || []).includes(newCensoredWord.trim())}
                                             >
                                                 {t("common.add")}
                                             </Button>
                                         </form>
 
                                         <ScrollArea className="max-h-[150px] rounded-lg border bg-muted/20 p-3">
-                                            {(settings.censoredWords || []).length === 0 ? (
+                                            {(censoredWords || []).length === 0 ? (
                                                 <div className="text-sm text-muted-foreground text-center py-4">
                                                     {t("actionBar.censor.empty")}
                                                 </div>
                                             ) : (
                                                 <div className="flex flex-wrap gap-2">
-                                                    {(settings.censoredWords || []).map((word: string, index: number) => (
+                                                    {(censoredWords || []).map((word: string, index: number) => (
                                                         <Badge
                                                             key={word}
                                                             variant="secondary"
                                                             className="cursor-pointer select-none px-3 py-1.5 text-sm hover:bg-destructive hover:text-destructive-foreground"
                                                             onClick={() => {
-                                                                const updatedWords = (settings.censoredWords || []).filter((_: string, i: number) => i !== index);
+                                                                const updatedWords = (censoredWords || []).filter((_: string, i: number) => i !== index);
                                                                 updateSetting("censoredWords", updatedWords);
                                                             }}
                                                         >
@@ -268,7 +290,7 @@ export function TextFormattingPanel({
                             </DialogContent>
                         </Dialog>
                         <Switch
-                            checked={settings.enableCensor}
+                            checked={enableCensor}
                             onCheckedChange={(checked: boolean) => updateSetting("enableCensor", checked)}
                         />
                     </div>

--- a/AutoSubs-App/src/components/settings/track-selector.tsx
+++ b/AutoSubs-App/src/components/settings/track-selector.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Track } from "@/types"
-import { useSettings } from "@/contexts/SettingsContext"
+import { useSettingsStore } from "@/stores/settings-store"
 import { useTranslation } from "react-i18next"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { useIntegration } from "@/contexts/IntegrationContext"
@@ -15,15 +15,17 @@ interface TrackSelectorProps {
 
 export function TrackSelector({ inputTracks, isPremiereActive }: TrackSelectorProps) {
     const { t } = useTranslation()
-    const { settings, updateSetting } = useSettings()
+    const selectedInputTracksByApp = useSettingsStore((s) => s.selectedInputTracksByApp)
+    const exportRange = useSettingsStore((s) => s.exportRange)
+    const updateSetting = useSettingsStore((s) => s.updateSetting)
     const { selectedIntegration } = useIntegration()
 
     // Get selected tracks for the active application
-    const selectedTracks = settings.selectedInputTracksByApp[selectedIntegration] || []
+    const selectedTracks = selectedInputTracksByApp[selectedIntegration] || []
 
     const updateTracks = (newTracks: string[]) => {
         updateSetting("selectedInputTracksByApp", {
-            ...settings.selectedInputTracksByApp,
+            ...selectedInputTracksByApp,
             [selectedIntegration]: newTracks
         });
     };
@@ -69,7 +71,7 @@ export function TrackSelector({ inputTracks, isPremiereActive }: TrackSelectorPr
             {isPremiereActive && (
                 <div className="px-4 py-2 border-b bg-muted/10">
                     <Tabs 
-                        value={settings.exportRange || "entire"} 
+                        value={exportRange || "entire"}
                         onValueChange={(val) => updateSetting("exportRange", val as "entire" | "inout")}
                         className="w-full"
                     >

--- a/AutoSubs-App/src/components/subtitles/subtitle-viewer-panel.tsx
+++ b/AutoSubs-App/src/components/subtitles/subtitle-viewer-panel.tsx
@@ -41,7 +41,7 @@ import { useAdobe } from "@/contexts/AdobeContext";
 import { useIntegration } from "@/contexts/IntegrationContext";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useAudioPreview } from "@/contexts/AudioPreviewContext";
-import { Speaker, Settings, Template, Track } from "@/types";
+import { Speaker, Template, Track } from "@/types";
 import { useTranslation } from "react-i18next";
 import { PlusIcon, type PlusIconHandle } from "../ui/plus";
 import { listSubtitleDocuments, type SubtitleDocumentListItem } from "@/utils/file-utils";
@@ -490,7 +490,6 @@ function SubtitleContent({
 }
 
 interface AddToTimelineFooterProps {
-  settings: Settings;
   timelineInfo: ReturnType<typeof useResolve>["timelineInfo"];
   templates: Template[];
   templatesLoading: boolean;
@@ -508,7 +507,6 @@ interface AddToTimelineFooterProps {
 }
 
 function AddToTimelineFooter({
-  settings,
   timelineInfo,
   templates,
   templatesLoading,
@@ -523,7 +521,6 @@ function AddToTimelineFooter({
   return (
     <div className="shrink-0 p-3 flex justify-end gap-2 border-t shadow-2xl">
       <AddToTimelineDialog
-        settings={settings}
         timelineInfo={timelineInfo}
         templates={templates}
         templatesLoading={templatesLoading}
@@ -640,7 +637,6 @@ export function SubtitleViewerPanel({
     [jumpToTime, seekAudioPreview],
   );
 
-  const settings = useSettingsStore();
   const { t } = useTranslation();
   const hasSubtitles = subtitles.length > 0;
 
@@ -716,7 +712,7 @@ export function SubtitleViewerPanel({
   const handleApplyReformat = async () => {
     await flushPendingSubtitleSave();
     const timelineId = timelineInfo?.timelineId || "";
-    await reformatSubtitles(settings, null, timelineId);
+    await reformatSubtitles(useSettingsStore.getState(), null, timelineId);
     setShowReformat(false);
   };
 
@@ -769,7 +765,7 @@ export function SubtitleViewerPanel({
           data-tauri-drag-region={isMacOs ? "false" : undefined}
         >
           <ImportExportPopover
-            onImport={() => importSubtitles(settings, null, "")}
+            onImport={() => importSubtitles(useSettingsStore.getState(), null, "")}
             onExport={(format) => exportSubtitlesAs(format, subtitles, speakers)}
             hasSubtitles={subtitles.length > 0}
             defaultTab={subtitles.length > 0 ? "export" : "import"}
@@ -850,7 +846,6 @@ export function SubtitleViewerPanel({
 
       {isIntegrationConnected && subtitles.length > 0 && (
         <AddToTimelineFooter
-          settings={settings}
           timelineInfo={timelineInfo}
           templates={isAdobeActive ? [] : resolveTemplates}
           templatesLoading={!isAdobeActive && resolveTemplatesLoading}

--- a/AutoSubs-App/src/components/subtitles/subtitle-viewer-panel.tsx
+++ b/AutoSubs-App/src/components/subtitles/subtitle-viewer-panel.tsx
@@ -39,9 +39,9 @@ import { useSubtitleDocument } from "@/contexts/SubtitleDocumentContext";
 import { useResolve } from "@/contexts/ResolveContext";
 import { useAdobe } from "@/contexts/AdobeContext";
 import { useIntegration } from "@/contexts/IntegrationContext";
-import { useSettings } from "@/contexts/SettingsContext";
+import { useSettingsStore } from "@/stores/settings-store";
 import { useAudioPreview } from "@/contexts/AudioPreviewContext";
-import { Speaker, Template, Track } from "@/types";
+import { Speaker, Settings, Template, Track } from "@/types";
 import { useTranslation } from "react-i18next";
 import { PlusIcon, type PlusIconHandle } from "../ui/plus";
 import { listSubtitleDocuments, type SubtitleDocumentListItem } from "@/utils/file-utils";
@@ -490,7 +490,7 @@ function SubtitleContent({
 }
 
 interface AddToTimelineFooterProps {
-  settings: ReturnType<typeof useSettings>["settings"];
+  settings: Settings;
   timelineInfo: ReturnType<typeof useResolve>["timelineInfo"];
   templates: Template[];
   templatesLoading: boolean;
@@ -640,7 +640,7 @@ export function SubtitleViewerPanel({
     [jumpToTime, seekAudioPreview],
   );
 
-  const { settings } = useSettings();
+  const settings = useSettingsStore();
   const { t } = useTranslation();
   const hasSubtitles = subtitles.length > 0;
 

--- a/AutoSubs-App/src/components/transcription/language-button.tsx
+++ b/AutoSubs-App/src/components/transcription/language-button.tsx
@@ -12,24 +12,26 @@ import {
   type ChevronsUpDownIconHandle,
 } from "@/components/ui/icons/chevrons-up-down";
 import { LanguageSelector } from "@/components/settings/language-selector";
-import { useSettings } from "@/contexts/SettingsContext";
+import { useSettingsStore } from "@/stores/settings-store";
 import { languages, translateLanguages } from "@/lib/languages";
 
 export function LanguageButton() {
   const { t } = useTranslation();
-  const { settings } = useSettings();
+  const language = useSettingsStore((s) => s.language);
+  const targetLanguage = useSettingsStore((s) => s.targetLanguage);
+  const translate = useSettingsStore((s) => s.translate);
   const [open, setOpen] = React.useState(false);
   const chevronsRef = React.useRef<ChevronsUpDownIconHandle>(null);
 
   const sourceLanguageLabel =
-    settings.language === "auto"
+    language === "auto"
       ? t("actionBar.common.auto")
-      : languages.find((l) => l.value === settings.language)?.label ??
-        settings.language;
+      : languages.find((l) => l.value === language)?.label ??
+        language;
 
   const targetLanguageLabel =
-    translateLanguages.find((l) => l.value === settings.targetLanguage)
-      ?.label ?? settings.targetLanguage;
+    translateLanguages.find((l) => l.value === targetLanguage)
+      ?.label ?? targetLanguage;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -48,7 +50,7 @@ export function LanguageButton() {
             <span className="min-w-0 truncate text-sm font-semibold leading-none group-hover:text-primary transition-colors">
               {sourceLanguageLabel}
             </span>
-            {settings.translate ? (
+            {translate ? (
               <>
                 <ArrowRight className="size-4 shrink-0 text-muted-foreground" />
                 <span className="min-w-0 truncate text-sm font-semibold leading-none group-hover:text-primary transition-colors">

--- a/AutoSubs-App/src/components/transcription/options-row.tsx
+++ b/AutoSubs-App/src/components/transcription/options-row.tsx
@@ -11,13 +11,16 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { SpeakerSelector } from "@/components/settings/diarize-selector";
 import { TextFormattingPanel } from "@/components/settings/text-formatting-panel";
-import { useSettings } from "@/contexts/SettingsContext";
+import { useSettingsStore } from "@/stores/settings-store";
 import { cn } from "@/lib/utils";
 import { migrateCustomPrompt } from "./utils";
 
 export function OptionsRow() {
   const { t } = useTranslation();
-  const { settings: currentSettings, updateSetting } = useSettings();
+  const enableDiarize = useSettingsStore((s) => s.enableDiarize);
+  const maxSpeakers = useSettingsStore((s) => s.maxSpeakers);
+  const customPrompt = useSettingsStore((s) => s.customPrompt);
+  const updateSetting = useSettingsStore((s) => s.updateSetting);
   const containerRef = React.useRef<HTMLDivElement>(null);
   const [openSpeakerPopover, setOpenSpeakerPopover] = React.useState(false);
   const [openTextFormattingPopover, setOpenTextFormattingPopover] =
@@ -46,10 +49,10 @@ export function OptionsRow() {
     return () => observer.disconnect();
   }, []);
 
-  const diarizeLabel = currentSettings.enableDiarize
-    ? currentSettings.maxSpeakers === null
+  const diarizeLabel = enableDiarize
+    ? maxSpeakers === null
       ? t("actionBar.common.auto")
-      : currentSettings.maxSpeakers
+      : maxSpeakers
     : t("actionBar.common.off");
 
   return (
@@ -129,7 +132,7 @@ export function OptionsRow() {
         open={openCustomPromptPopover}
         onOpenChange={setOpenCustomPromptPopover}
         showLabel={showPromptOptionLabel}
-        customPrompt={currentSettings.customPrompt}
+        customPrompt={customPrompt}
         onCustomPromptChange={(value) => updateSetting("customPrompt", value)}
       />
     </div>

--- a/AutoSubs-App/src/components/transcription/processing-steps-list.tsx
+++ b/AutoSubs-App/src/components/transcription/processing-steps-list.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { ProcessingStepItem } from "@/components/processing/processing-step-item";
-import { useSettingsStore } from "@/stores/settings-store";
 import type { TimelineInfo } from "@/types";
 import type { ProcessingStep } from "./utils";
 
@@ -34,7 +33,6 @@ export function ProcessingStepsList({
   onViewSubtitles,
   isSubtitleViewerOpen = false,
 }: ProcessingStepsListProps) {
-  const currentSettings = useSettingsStore();
   const { t } = useTranslation();
   const visibleSteps =
     isProcessing && steps.length === 0
@@ -79,7 +77,6 @@ export function ProcessingStepsList({
                 onViewSubtitles={onViewSubtitles}
                 isSubtitleViewerOpen={isSubtitleViewerOpen}
                 livePreviewSegments={livePreviewSegments}
-                settings={currentSettings}
                 timelineInfo={timelineInfo}
                 selectedIntegration={selectedIntegration}
               />

--- a/AutoSubs-App/src/components/transcription/processing-steps-list.tsx
+++ b/AutoSubs-App/src/components/transcription/processing-steps-list.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { ProcessingStepItem } from "@/components/processing/processing-step-item";
-import { useSettings } from "@/contexts/SettingsContext";
+import { useSettingsStore } from "@/stores/settings-store";
 import type { TimelineInfo } from "@/types";
 import type { ProcessingStep } from "./utils";
 
@@ -34,7 +34,7 @@ export function ProcessingStepsList({
   onViewSubtitles,
   isSubtitleViewerOpen = false,
 }: ProcessingStepsListProps) {
-  const { settings: currentSettings } = useSettings();
+  const currentSettings = useSettingsStore();
   const { t } = useTranslation();
   const visibleSteps =
     isProcessing && steps.length === 0

--- a/AutoSubs-App/src/components/transcription/run-summary.tsx
+++ b/AutoSubs-App/src/components/transcription/run-summary.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { Card } from "@/components/ui/card";
-import { useSettings } from "@/contexts/SettingsContext";
+import { useSettingsStore } from "@/stores/settings-store";
 import { languages, translateLanguages } from "@/lib/languages";
 import type { Model } from "@/types";
 
@@ -29,47 +29,57 @@ function useRunSummary(
   selectedModelIndex: number,
 ): string {
   const { t } = useTranslation();
-  const { settings } = useSettings();
+  const audioInputMode = useSettingsStore((s) => s.audioInputMode);
+  const language = useSettingsStore((s) => s.language);
+  const targetLanguage = useSettingsStore((s) => s.targetLanguage);
+  const translate = useSettingsStore((s) => s.translate);
+  const enableDiarize = useSettingsStore((s) => s.enableDiarize);
+  const maxSpeakers = useSettingsStore((s) => s.maxSpeakers);
+  const textDensity = useSettingsStore((s) => s.textDensity);
+  const textCase = useSettingsStore((s) => s.textCase);
+  const enableGpu = useSettingsStore((s) => s.enableGpu);
+  const enableDTW = useSettingsStore((s) => s.enableDTW);
+  const removePunctuation = useSettingsStore((s) => s.removePunctuation);
 
   const sourceModeLabel =
-    settings.audioInputMode === "timeline"
+    audioInputMode === "timeline"
       ? t("actionBar.mode.timeline")
       : t("actionBar.mode.fileInput");
 
   const selectedModelLabel = t(modelsState[selectedModelIndex].label);
 
   const sourceLanguageLabel =
-    settings.language === "auto"
+    language === "auto"
       ? t("actionBar.common.auto")
-      : languages.find((l) => l.value === settings.language)?.label ??
-        settings.language;
+      : languages.find((l) => l.value === language)?.label ??
+        language;
 
   const targetLanguageLabel =
-    translateLanguages.find((l) => l.value === settings.targetLanguage)
-      ?.label ?? settings.targetLanguage;
+    translateLanguages.find((l) => l.value === targetLanguage)
+      ?.label ?? targetLanguage;
 
-  const languageSummary = settings.translate
+  const languageSummary = translate
     ? `${sourceLanguageLabel} → ${targetLanguageLabel}`
     : sourceLanguageLabel;
 
-  const diarizeLabel = settings.enableDiarize
-    ? settings.maxSpeakers === null
+  const diarizeLabel = enableDiarize
+    ? maxSpeakers === null
       ? t("actionBar.common.auto")
-      : settings.maxSpeakers
+      : maxSpeakers
     : t("actionBar.common.off");
 
   const textDensityLabel = t(
-    `actionBar.format.textDensity.${settings.textDensity}`,
+    `actionBar.format.textDensity.${textDensity}`,
   );
 
   const textCaseLabel =
-    settings.textCase !== "none"
-      ? t(`actionBar.format.textCase.${settings.textCase}`)
+    textCase !== "none"
+      ? t(`actionBar.format.textCase.${textCase}`)
       : "";
 
-  const gpuLabel = settings.enableGpu ? t("settings.gpu.title") : "";
-  const dtwLabel = settings.enableDTW ? t("settings.dtw.title") : "";
-  const punctuationLabel = settings.removePunctuation
+  const gpuLabel = enableGpu ? t("settings.gpu.title") : "";
+  const dtwLabel = enableDTW ? t("settings.dtw.title") : "";
+  const punctuationLabel = removePunctuation
     ? t("actionBar.format.removePunctuationTitle")
     : "";
 
@@ -79,22 +89,22 @@ function useRunSummary(
     languageSummary,
   ];
 
-  if (settings.enableDiarize) {
+  if (enableDiarize) {
     summaryParts.push(`${t("actionBar.speakers.title")}: ${diarizeLabel}`);
   }
-  if (settings.textDensity !== "standard") {
+  if (textDensity !== "standard") {
     summaryParts.push(textDensityLabel);
   }
-  if (settings.enableGpu) {
+  if (enableGpu) {
     summaryParts.push(gpuLabel);
   }
-  if (settings.enableDTW) {
+  if (enableDTW) {
     summaryParts.push(dtwLabel);
   }
-  if (settings.textCase !== "none") {
+  if (textCase !== "none") {
     summaryParts.push(textCaseLabel);
   }
-  if (settings.removePunctuation) {
+  if (removePunctuation) {
     summaryParts.push(punctuationLabel);
   }
 

--- a/AutoSubs-App/src/components/transcription/source-section.tsx
+++ b/AutoSubs-App/src/components/transcription/source-section.tsx
@@ -16,7 +16,7 @@ import {
   type UploadIconHandle,
 } from "@/components/ui/icons/upload";
 import { cn } from "@/lib/utils";
-import { useSettings } from "@/contexts/SettingsContext";
+import { useSettingsStore } from "@/stores/settings-store";
 import type { Track } from "@/types";
 import { SUPPORTED_MEDIA_EXTENSIONS, isVideoExtension } from "./utils";
 import { MediaPlayer } from "@/components/media/media-player";
@@ -225,11 +225,13 @@ export function TimelineTrackSelector({
   className,
 }: TimelineTrackSelectorProps) {
   const { t, i18n } = useTranslation();
-  const { settings: currentSettings, updateSetting } = useSettings();
+  const selectedInputTracksByApp = useSettingsStore((s) => s.selectedInputTracksByApp);
+  const exportRange = useSettingsStore((s) => s.exportRange);
+  const updateSetting = useSettingsStore((s) => s.updateSetting);
   const [isSpinning, setIsSpinning] = React.useState(false);
 
   const selectedTracks =
-    currentSettings.selectedInputTracksByApp[selectedIntegration] || [];
+    selectedInputTracksByApp[selectedIntegration] || [];
   const selectedTrackCount = selectedTracks.length;
   const formatTrackNumber = React.useCallback(
     (value: number) => formatLocalizedTrackNumber(value, i18n.language),
@@ -239,21 +241,21 @@ export function TimelineTrackSelector({
   const toggleInputTrack = React.useCallback(
     (trackId: string) => {
       const currentTracks =
-        currentSettings.selectedInputTracksByApp[selectedIntegration] || [];
+        selectedInputTracksByApp[selectedIntegration] || [];
       const isSelected = currentTracks.includes(trackId);
       const nextTracks = isSelected
         ? currentTracks.filter((id: string) => id !== trackId)
         : [...currentTracks, trackId];
 
       const nextMap = {
-        ...currentSettings.selectedInputTracksByApp,
+        ...selectedInputTracksByApp,
         [selectedIntegration]: nextTracks,
       };
 
       updateSetting("selectedInputTracksByApp", nextMap);
     },
     [
-      currentSettings.selectedInputTracksByApp,
+      selectedInputTracksByApp,
       selectedIntegration,
       updateSetting,
     ],
@@ -298,7 +300,7 @@ export function TimelineTrackSelector({
             <label className="flex shrink-0 cursor-pointer items-center gap-2 text-xs font-medium text-muted-foreground">
               <span>{t("actionBar.tracks.exportRange.inout")}</span>
               <Switch
-                checked={currentSettings.exportRange === "inout"}
+                checked={exportRange === "inout"}
                 onCheckedChange={(checked) =>
                   updateSetting("exportRange", checked ? "inout" : "entire")
                 }

--- a/AutoSubs-App/src/components/transcription/transcription-panel-view.tsx
+++ b/AutoSubs-App/src/components/transcription/transcription-panel-view.tsx
@@ -5,11 +5,10 @@ import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { ModelPicker } from "@/components/settings/model-picker";
-import { useSettings } from "@/contexts/SettingsContext";
+import { useSettingsStore } from "@/stores/settings-store";
 import { cn } from "@/lib/utils";
 import type {
   Model,
-  Settings,
   TimelineInfo,
   Track,
 } from "@/types";
@@ -54,7 +53,6 @@ export interface TranscriptionPanelViewProps {
   onTranscriptDocumentsRefresh: () => Promise<void>;
   livePreviewSegments: any[];
   isSubtitleViewerOpen?: boolean;
-  settings: Settings;
   timelineInfo: TimelineInfo;
   templates: TimelineInfo["templates"];
   templatesLoading: boolean;
@@ -107,7 +105,8 @@ export function TranscriptionPanelView({
   selectedIntegration,
 }: TranscriptionPanelViewProps) {
   const { t, i18n } = useTranslation();
-  const { settings: currentSettings, updateSetting } = useSettings();
+  const selectedInputTracksByApp = useSettingsStore((s) => s.selectedInputTracksByApp);
+  const updateSetting = useSettingsStore((s) => s.updateSetting);
 
   const [localSelectedFile, setLocalSelectedFile] = React.useState<
     string | null
@@ -171,7 +170,7 @@ export function TranscriptionPanelView({
   // Clean up selected tracks that no longer exist (runs on both manual and auto refresh)
   React.useEffect(() => {
     const currentSelectedTracks =
-      currentSettings.selectedInputTracksByApp[selectedIntegration] || [];
+      selectedInputTracksByApp[selectedIntegration] || [];
     const validTrackIds = inputTracks.map((track) => track.value);
     const cleanedSelectedTracks = currentSelectedTracks.filter((trackId: string) =>
       validTrackIds.includes(trackId)
@@ -179,15 +178,15 @@ export function TranscriptionPanelView({
 
     if (cleanedSelectedTracks.length !== currentSelectedTracks.length) {
       const nextMap = {
-        ...currentSettings.selectedInputTracksByApp,
+        ...selectedInputTracksByApp,
         [selectedIntegration]: cleanedSelectedTracks,
       };
       updateSetting("selectedInputTracksByApp", nextMap);
     }
-  }, [inputTracks, currentSettings.selectedInputTracksByApp, selectedIntegration, updateSetting]);
+  }, [inputTracks, selectedInputTracksByApp, selectedIntegration, updateSetting]);
 
   const selectedTracks =
-    currentSettings.selectedInputTracksByApp[selectedIntegration] || [];
+    selectedInputTracksByApp[selectedIntegration] || [];
   const selectedTrackCount = selectedTracks.length;
   const hasProcessingSteps = processingSteps.length > 0;
   const showProcessing = isProcessing || hasProcessingSteps;
@@ -195,8 +194,8 @@ export function TranscriptionPanelView({
 
   const startDisabled =
     isProcessing ||
-    (currentSettings.audioInputMode === "file" && !selectedFile) ||
-    (currentSettings.audioInputMode === "timeline" &&
+    (audioInputMode === "file" && !selectedFile) ||
+    (audioInputMode === "timeline" &&
       (selectedTrackCount === 0 || inputTracks.length === 0));
 
   const formatSectionNumber = React.useCallback(
@@ -205,7 +204,7 @@ export function TranscriptionPanelView({
   );
 
   const startButtonLabel =
-    currentSettings.audioInputMode === "timeline" &&
+    audioInputMode === "timeline" &&
     selectedTrackCount > 0 &&
     inputTracks.length > 0
       ? `${t("common.generateSubtitles")} (${selectedTrackCount})`
@@ -288,7 +287,7 @@ export function TranscriptionPanelView({
                         isRefreshingTracks={isRefreshingTracks}
                         className={cn(
                           "row-start-1 col-start-1 transition-opacity duration-0",
-                          currentSettings.audioInputMode !== "timeline" && "opacity-0 pointer-events-none"
+                          audioInputMode !== "timeline" && "opacity-0 pointer-events-none"
                         )}
                       />
                       <FileDropArea
@@ -296,7 +295,7 @@ export function TranscriptionPanelView({
                         onSelectedFileChange={setSelectedFile}
                         className={cn(
                           "row-start-1 col-start-1 transition-opacity duration-0",
-                          currentSettings.audioInputMode !== "file" && "opacity-0 pointer-events-none"
+                          audioInputMode !== "file" && "opacity-0 pointer-events-none"
                         )}
                       />
                     </div>

--- a/AutoSubs-App/src/components/transcription/transcription-panel.tsx
+++ b/AutoSubs-App/src/components/transcription/transcription-panel.tsx
@@ -5,7 +5,8 @@ import { useMediaQuery } from "@/hooks/use-media-query";
 import { useModels } from "@/contexts/ModelsContext";
 import { useProgress } from "@/contexts/ProgressContext";
 import { useSubtitleDocument } from "@/contexts/SubtitleDocumentContext";
-import { useSettings } from "@/contexts/SettingsContext";
+import { useShallow } from "zustand/react/shallow";
+import { useSettingsStore } from "@/stores/settings-store";
 import { useResolve } from "@/contexts/ResolveContext";
 import { useAdobe } from "@/contexts/AdobeContext";
 import { useIntegration } from "@/contexts/IntegrationContext";
@@ -44,7 +45,50 @@ export function TranscriptionPanel({
     exportSubtitlesAs,
     loadSubtitles,
   } = useSubtitleDocument();
-  const { settings, updateSetting } = useSettings();
+  const {
+    selectedInputTracksByApp,
+    model,
+    language,
+    translate,
+    targetLanguage,
+    audioInputMode,
+    enableDTW,
+    enableGpu,
+    enableDiarize,
+    maxSpeakers,
+    textDensity,
+    maxLinesPerSubtitle,
+    customMaxCharsPerLine,
+    textCase,
+    removePunctuation,
+    enableCensor,
+    customPrompt,
+    transcriptionsCompleted,
+    subSlateMilestoneShown,
+  } = useSettingsStore(
+    useShallow((s) => ({
+      selectedInputTracksByApp: s.selectedInputTracksByApp,
+      model: s.model,
+      language: s.language,
+      translate: s.translate,
+      targetLanguage: s.targetLanguage,
+      audioInputMode: s.audioInputMode,
+      enableDTW: s.enableDTW,
+      enableGpu: s.enableGpu,
+      enableDiarize: s.enableDiarize,
+      maxSpeakers: s.maxSpeakers,
+      textDensity: s.textDensity,
+      maxLinesPerSubtitle: s.maxLinesPerSubtitle,
+      customMaxCharsPerLine: s.customMaxCharsPerLine,
+      textCase: s.textCase,
+      removePunctuation: s.removePunctuation,
+      enableCensor: s.enableCensor,
+      customPrompt: s.customPrompt,
+      transcriptionsCompleted: s.transcriptionsCompleted,
+      subSlateMilestoneShown: s.subSlateMilestoneShown,
+    })),
+  );
+  const updateSetting = useSettingsStore((s) => s.updateSetting);
   const { modelsState, downloadedModelValues, checkDownloadedModels } =
     useModels();
   const {
@@ -100,7 +144,7 @@ export function TranscriptionPanel({
 
   // Senior Pattern: derive active tracks from the app-aware map instead of a global list
   const activeSelectedTracks =
-    settings.selectedInputTracksByApp[selectedIntegration] || [];
+    selectedInputTracksByApp[selectedIntegration] || [];
   const cancelExport = resolveCancelExport; // Fallback for cancel
   const setIsExporting = resolveSetIsExporting; // Fallback
   const setExportProgress = resolveSetExportProgress; // Fallback
@@ -171,34 +215,34 @@ export function TranscriptionPanel({
     }
   }, [processingSteps]);
 
-  const isModelCached = modelsState[settings.model]?.isDownloaded ?? false;
+  const isModelCached = modelsState[model]?.isDownloaded ?? false;
   const isDiarizeModelDownloaded = downloadedModelValues.includes(
     diarizeModel.value,
   );
   const hasPendingDownloads =
-    !isModelCached || (settings.enableDiarize && !isDiarizeModelDownloaded);
+    !isModelCached || (enableDiarize && !isDiarizeModelDownloaded);
 
   React.useEffect(() => {
     const cleanup = setupEventListeners({
-      targetLanguage: settings.targetLanguage,
-      language: settings.language,
-      isResolveMode: settings.audioInputMode === "timeline",
+      targetLanguage,
+      language,
+      isResolveMode: audioInputMode === "timeline",
       hasPendingDownloads,
-      enableDiarize: settings.enableDiarize,
+      enableDiarize,
     });
 
     return cleanup;
   }, [
     setupEventListeners,
-    settings.targetLanguage,
-    settings.language,
-    settings.audioInputMode,
+    targetLanguage,
+    language,
+    audioInputMode,
     hasPendingDownloads,
-    settings.enableDiarize,
+    enableDiarize,
   ]);
 
   React.useEffect(() => {
-    if (settings.audioInputMode === "timeline" && isExporting) {
+    if (audioInputMode === "timeline" && isExporting) {
       updateProgressStep({
         progress: exportProgress,
         type: "Export",
@@ -207,7 +251,7 @@ export function TranscriptionPanel({
   }, [
     isExporting,
     exportProgress,
-    settings.audioInputMode,
+    audioInputMode,
     updateProgressStep,
   ]);
 
@@ -258,27 +302,27 @@ export function TranscriptionPanel({
     setLabeledProgress(null);
     cancelRequestedRef.current = false;
     setFileInput(null);
-    if (settings.audioInputMode === "timeline") {
+    if (audioInputMode === "timeline") {
       await refreshAudioTracks();
     }
   }, [
     cancelRequestedRef,
     clearProgressSteps,
     refreshAudioTracks,
-    settings.audioInputMode,
+    audioInputMode,
     setExportProgress,
     setIsExporting,
     setFileInput,
   ]);
 
   const handleStartTranscription = async () => {
-    if (settings.audioInputMode === "timeline" && !timelineInfo.timelineId) {
+    if (audioInputMode === "timeline" && !timelineInfo.timelineId) {
       console.error("No timeline selected");
       return;
     }
 
     cancelRequestedRef.current = false;
-    if (settings.audioInputMode === "file" && !fileInput) {
+    if (audioInputMode === "file" && !fileInput) {
       console.error("No file selected");
       return;
     }
@@ -288,16 +332,16 @@ export function TranscriptionPanel({
     clearProgressSteps();
 
     setupEventListeners({
-      targetLanguage: settings.targetLanguage,
-      language: settings.language,
-      isResolveMode: settings.audioInputMode === "timeline",
+      targetLanguage,
+      language,
+      isResolveMode: audioInputMode === "timeline",
       hasPendingDownloads,
-      enableDiarize: settings.enableDiarize,
+      enableDiarize,
     });
 
     try {
       const audioInfo = await getSourceAudio(
-        settings.audioInputMode,
+        audioInputMode,
         fileInput,
         activeSelectedTracks,
       );
@@ -312,24 +356,24 @@ export function TranscriptionPanel({
       const options: TranscriptionOptions = {
         audioPath: audioInfo.path,
         offset: Math.round(audioInfo.offset * 1000) / 1000,
-        model: modelsState[settings.model].value,
-        lang: settings.language,
-        translate: settings.translate,
-        targetLanguage: settings.targetLanguage,
-        enableDtw: settings.enableDTW,
-        enableGpu: settings.enableGpu,
-        enableDiarize: settings.enableDiarize,
-        maxSpeakers: settings.maxSpeakers,
-        density: settings.textDensity,
-        maxLines: settings.maxLinesPerSubtitle,
+        model: modelsState[model].value,
+        lang: language,
+        translate,
+        targetLanguage,
+        enableDtw: enableDTW,
+        enableGpu,
+        enableDiarize,
+        maxSpeakers,
+        density: textDensity,
+        maxLines: maxLinesPerSubtitle,
         customMaxCharsPerLine:
-          settings.textDensity === "custom"
-            ? settings.customMaxCharsPerLine
+          textDensity === "custom"
+            ? customMaxCharsPerLine
             : undefined,
-        textCase: settings.textCase,
-        removePunctuation: settings.removePunctuation,
-        censoredWords: settings.enableCensor ? getActiveCensorWords(settings) : [],
-        customPrompt: settings.customPrompt.trim() || undefined,
+        textCase,
+        removePunctuation,
+        censoredWords: enableCensor ? getActiveCensorWords(useSettingsStore.getState()) : [],
+        customPrompt: customPrompt.trim() || undefined,
       };
 
       const transcript = await invoke("transcribe_audio", { options });
@@ -338,16 +382,16 @@ export function TranscriptionPanel({
 
       await processTranscriptionResults(
         transcript as any,
-        settings,
+        useSettingsStore.getState(),
         fileInput,
         timelineInfo.timelineId,
       );
       await onTranscriptCreated?.();
       onViewSubtitles?.();
 
-      const nextCount = (settings.transcriptionsCompleted ?? 0) + 1;
+      const nextCount = (transcriptionsCompleted ?? 0) + 1;
       updateSetting("transcriptionsCompleted", nextCount);
-      if (nextCount >= 10 && !settings.subSlateMilestoneShown) {
+      if (nextCount >= 10 && !subSlateMilestoneShown) {
         setShowSubSlate(true);
       }
     } catch (error) {
@@ -423,8 +467,8 @@ export function TranscriptionPanel({
         <div className="flex-1 min-h-0">
           <TranscriptionPanelView
             modelsState={modelsState}
-            selectedModelIndex={settings.model}
-            selectedLanguage={settings.language}
+            selectedModelIndex={model}
+            selectedLanguage={language}
             onSelectModel={(modelIndex) => {
               updateSetting("model", modelIndex);
             }}
@@ -433,7 +477,7 @@ export function TranscriptionPanel({
             openModelSelector={openModelSelector}
             onOpenModelSelectorChange={setOpenModelSelector}
             isSmallScreen={isSmallScreen}
-            audioInputMode={settings.audioInputMode}
+            audioInputMode={audioInputMode}
             onAudioInputModeChange={(mode) =>
               updateSetting("audioInputMode", mode)
             }
@@ -447,7 +491,6 @@ export function TranscriptionPanel({
             onTranscriptDocumentsRefresh={onTranscriptDocumentsRefresh}
             isSubtitleViewerOpen={isSubtitleViewerOpen}
             livePreviewSegments={livePreviewSegments}
-            settings={settings}
             timelineInfo={timelineInfo}
             templates={isPremiereActive ? [] : resolveTemplates}
             templatesLoading={isPremiereActive ? false : resolveTemplatesLoading}

--- a/AutoSubs-App/src/contexts/AdobeContext.tsx
+++ b/AutoSubs-App/src/contexts/AdobeContext.tsx
@@ -6,7 +6,7 @@ import { requestSequenceInfo, requestAudioExport, requestImportSRT, requestJumpT
 import { getAudioExportDir, getSubtitleDocumentPath, loadSubtitleDocumentSubtitles } from '@/utils/file-utils';
 import { generateSrt } from '@/utils/srt-utils';
 import { writeTextFile } from '@tauri-apps/plugin-fs';
-import { useSettings } from '@/contexts/SettingsContext';
+import { useSettingsStore } from '@/stores/settings-store';
 import { useIntegration } from '@/contexts/IntegrationContext';
 
 interface AdobeContextType {
@@ -52,7 +52,7 @@ function toTimelineInfo(data: any): TimelineInfo {
 }
 
 export function AdobeProvider({ children }: { children: React.ReactNode }) {
-  const { settings: currentSettings } = useSettings();
+  const exportRange = useSettingsStore((s) => s.exportRange);
   const { selectedIntegration } = useIntegration();
 
   const [appConnections, setAppConnections] = useState<Record<string, boolean>>({
@@ -209,8 +209,7 @@ export function AdobeProvider({ children }: { children: React.ReactNode }) {
     try {
       const exportDir = await getAudioExportDir();
       const tracks = inputTracks.map(Number).filter(n => !isNaN(n));
-      const exportRange = currentSettings.exportRange || 'entire';
-      const result = await sendRequestAndWait((sid) => requestAudioExport(exportDir, tracks, exportRange, '', sid, selectedIntegration));
+      const result = await sendRequestAndWait((sid) => requestAudioExport(exportDir, tracks, exportRange || 'entire', '', sid, selectedIntegration));
       const data = typeof result === 'string' ? JSON.parse(result) : result;
       if (data && data.success) {
         setExportProgress(100);

--- a/AutoSubs-App/src/contexts/IntegrationContext.tsx
+++ b/AutoSubs-App/src/contexts/IntegrationContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext } from 'react';
-import { useSettings } from '@/contexts/SettingsContext';
+import { useSettingsStore } from '@/stores/settings-store';
 
 export type Integration = "davinci" | "premiere" | "aftereffects";
 
@@ -11,8 +11,8 @@ interface IntegrationContextType {
 const IntegrationContext = createContext<IntegrationContextType | null>(null);
 
 export function IntegrationProvider({ children }: { children: React.ReactNode }) {
-  const { settings, updateSetting } = useSettings();
-  const selectedIntegration = settings.preferredEditorIntegration;
+  const selectedIntegration = useSettingsStore((s) => s.preferredEditorIntegration);
+  const updateSetting = useSettingsStore((s) => s.updateSetting);
   const setSelectedIntegration = React.useCallback((integration: Integration) => {
     updateSetting("preferredEditorIntegration", integration);
   }, [updateSetting]);

--- a/AutoSubs-App/src/contexts/ResolveContext.tsx
+++ b/AutoSubs-App/src/contexts/ResolveContext.tsx
@@ -3,7 +3,7 @@ import { toast } from 'sonner';
 import { Template, TimelineInfo } from '@/types';
 import { getTimelineInfo, getTemplates, cancelExport, addSubtitlesToTimeline } from '@/api/resolve-api';
 import { useIntegration } from '@/contexts/IntegrationContext';
-import { useSettings } from '@/contexts/SettingsContext';
+import { useSettingsStore } from '@/stores/settings-store';
 import { validateExportedAudioFile } from '@/utils/file-utils';
 
 interface ResolveContextType {
@@ -30,7 +30,7 @@ const ResolveContext = createContext<ResolveContextType | null>(null);
 
 export function ResolveProvider({ children }: { children: React.ReactNode }) {
   const { selectedIntegration } = useIntegration();
-  const { settings } = useSettings();
+  const exportRange = useSettingsStore((s) => s.exportRange);
   const [timelineInfo, setTimelineInfo] = useState<TimelineInfo>({ name: "", timelineId: "", templates: [], inputTracks: [], outputTracks: [], projectName: "" });
   const [templates, setTemplates] = useState<Template[]>([]);
   const [templatesLoading, setTemplatesLoading] = useState(false);
@@ -175,7 +175,7 @@ export function ResolveProvider({ children }: { children: React.ReactNode }) {
         const { exportAudio, getExportProgress } = await import('@/api/resolve-api');
 
         // Start the export (non-blocking)
-        const exportResult = await exportAudio(inputTracks, settings.exportRange || "entire");
+        const exportResult = await exportAudio(inputTracks, exportRange || "entire");
         console.log("Export started:", exportResult);
 
         // Poll for export progress until completion.

--- a/AutoSubs-App/src/contexts/SettingsContext.tsx
+++ b/AutoSubs-App/src/contexts/SettingsContext.tsx
@@ -1,77 +1,18 @@
-import React, { createContext, useContext, useState, useEffect } from "react";
-import { load, Store } from "@tauri-apps/plugin-store";
-import { platform } from "@tauri-apps/plugin-os";
+import React, { useEffect, useState } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { Settings } from "@/types";
-import { getPreferredUiLanguage, initI18n, normalizeUiLanguage } from "@/i18n";
-import {
-  models,
-  modelSupportsLanguage,
-  getFirstRecommendedModelForLanguage,
-} from "@/lib/models";
-import { DEFAULT_PRESET_ID } from "@/presets/built-in-presets";
+import { initI18n } from "@/i18n";
 import { loadFontForLanguage } from "@/lib/font-loader";
+import {
+  useSettingsStore,
+  hydrateSettingsStore,
+  DEFAULT_SETTINGS,
+} from "@/stores/settings-store";
 
-export const DEFAULT_SETTINGS: Settings = {
-  // Mode
-  audioInputMode: "timeline",
-  preferredEditorIntegration: "davinci",
-
-  // UI settings
-  uiLanguage: "en",
-  onboardingCompleted: false,
-  tourCompleted: false,
-  lastSeenVersion: "",
-  showEnglishOnlyModels: false,
-
-  // Survey notification settings
-  timesDismissedSurvey: 0,
-  lastSurveyDate: new Date().toISOString(),
-
-  // Milestone tracking
-  transcriptionsCompleted: 0,
-  subSlateMilestoneShown: false,
-
-  // Processing settings
-  model: 0,
-  language: "auto",
-  translate: false,
-  targetLanguage: "en",
-  enableDTW: true,
-  enableGpu: true, // gpu enabled by default on mac and linux, disabled by default on windows
-  enableDiarize: false,
-  maxSpeakers: null,
-  exportRange: "inout",
-
-  // Text settings
-  textDensity: "standard",
-  maxLinesPerSubtitle: 1,
-  splitOnPunctuation: true,
-  textCase: "none",
-  removePunctuation: false,
-  enableCensor: false,
-  censoredWords: [],
-  activeCensorLists: [],
-  customPrompt: "",
-  customMaxCharsPerLine: 38,
-
-  // Resolve settings
-  selectedInputTracksByApp: {
-    "davinci": ["1"],
-    "premiere": [],
-    "aftereffects": []
-  },
-  selectedOutputTrack: "1",
-  selectedTemplate: { value: "Default Template", label: "Default Template" },
-
-  // AutoSubs Caption settings
-  presetId: DEFAULT_PRESET_ID,
-  captionMode: "animated",
-
-  // Animation settings
-  animationType: "none",
-  highlightType: "none",
-  highlightColor: "#000000",
-};
+// Re-export so existing `import { DEFAULT_SETTINGS } from "@/contexts/SettingsContext"`
+// continues to work, and the constant has a single source of truth in the store.
+export { DEFAULT_SETTINGS };
+export type { Settings };
 
 interface SettingsContextType {
   settings: Settings;
@@ -80,181 +21,92 @@ interface SettingsContextType {
   isHydrated: boolean;
 }
 
-const SettingsContext = createContext<SettingsContextType | null>(null);
+/**
+ * Drop-in replacement for the previous Context-based `useSettings` hook.
+ *
+ * Backed by the global zustand store (`useSettingsStore`). The `settings`
+ * object is selected with `useShallow` so a component only re-renders when
+ * one of the actual settings fields changes — not when `isHydrated` or the
+ * action references change. This is a marginal improvement over the old
+ * Context which re-rendered all 22 consumers on any settings change.
+ *
+ * Consumers can later opt into fine-grained selectors by importing
+ * `useSettingsStore` directly, e.g.:
+ *   const model = useSettingsStore((s) => s.model);
+ */
+export function useSettings(): SettingsContextType {
+  const settings = useSettingsStore(
+    useShallow((s) => {
+      const {
+        isHydrated: _h,
+        updateSetting: _u,
+        resetSettings: _r,
+        setHydrated: _sh,
+        ...rest
+      } = s;
+      return rest as Settings;
+    }),
+  );
+  const updateSetting = useSettingsStore((s) => s.updateSetting);
+  const resetSettings = useSettingsStore((s) => s.resetSettings);
+  const isHydrated = useSettingsStore((s) => s.isHydrated);
 
+  return { settings, updateSetting, resetSettings, isHydrated };
+}
+
+/**
+ * SettingsProvider — handles store rehydration on mount and gates the
+ * rendering of children until settings are loaded from disk. Also runs
+ * i18n and font-loading side-effects in response to settings changes.
+ *
+ * No longer wraps children in a React Context Provider; the zustand store
+ * is global and accessible via `useSettingsStore` / `useSettings()` from
+ * anywhere in the tree.
+ */
 export function SettingsProvider({ children }: { children: React.ReactNode }) {
-  const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS);
-  const [store, setStore] = useState<Store | null>(null);
-  const [isHydrated, setIsHydrated] = useState(false);
+  const isHydrated = useSettingsStore((s) => s.isHydrated);
   const [shouldShowChildren, setShouldShowChildren] = useState(false);
 
-  async function initializeStore() {
-    try {
-      const loadedStore = await load("autosubs-store.json", {
-        autoSave: false,
-      });
-
-      const currentPlatform = await platform();
-      const isWindows = currentPlatform === "windows";
-
-      // If you store settings as a single object, you can get it all at once
-      // Alternatively, if they are stored individually, you can reconstruct the object here.
-      const storedSettings = await loadedStore.get<any>("settings");
-      const hydratedSettings = storedSettings
-        ? ({
-            ...DEFAULT_SETTINGS,
-            ...storedSettings,
-            // Migration: if selectedInputTracksByApp doesn't exist but selectedInputTracks does,
-            // use it for both davinci and premiere to preserve user state.
-            selectedInputTracksByApp: storedSettings.selectedInputTracksByApp || {
-              "davinci": storedSettings.selectedInputTracks || ["1"],
-              "premiere": storedSettings.selectedInputTracks || [],
-              "aftereffects": []
-            },
-            uiLanguage: storedSettings.onboardingCompleted
-              ? normalizeUiLanguage(storedSettings.uiLanguage)
-              : getPreferredUiLanguage(),
-            // Migration: convert old isStandaloneMode boolean to audioInputMode enum
-            audioInputMode:
-              storedSettings.audioInputMode ??
-              (storedSettings.isStandaloneMode ? "file" : "timeline"),
-          } as Settings)
-        : ({
-            ...DEFAULT_SETTINGS,
-            enableDTW: !isWindows,
-            uiLanguage: getPreferredUiLanguage(),
-          } as Settings);
-
-      initI18n(hydratedSettings.uiLanguage);
-      setSettings(hydratedSettings);
-      setStore(loadedStore);
-    } catch (error) {
-      console.error("Error initializing store:", error);
-    } finally {
-      setIsHydrated(true);
-    }
-  }
-
-  // Initialization useEffect
+  // Trigger manual rehydration from the Tauri store on mount. This handles
+  // platform detection (for first-run enableDTW default) and field-level
+  // migrations before marking the store as hydrated.
   useEffect(() => {
-    initializeStore();
+    hydrateSettingsStore();
   }, []);
 
+  // Fade in children after hydration (matches previous opacity transition).
   useEffect(() => {
     if (!isHydrated) return;
     requestAnimationFrame(() => setShouldShowChildren(true));
   }, [isHydrated]);
 
+  // Re-initialise i18n when the UI language changes.
+  const uiLanguage = useSettingsStore((s) => s.uiLanguage);
   useEffect(() => {
     if (!isHydrated) return;
-    initI18n(settings.uiLanguage);
-  }, [settings.uiLanguage, isHydrated]);
+    initI18n(uiLanguage);
+  }, [uiLanguage, isHydrated]);
 
   // Lazy-load the appropriate font for the currently selected languages so
   // non-Latin text (CJK, Arabic, Devanagari, Thai, etc.) renders correctly.
+  const language = useSettingsStore((s) => s.language);
+  const translate = useSettingsStore((s) => s.translate);
+  const targetLanguage = useSettingsStore((s) => s.targetLanguage);
   useEffect(() => {
     if (!isHydrated) return;
-    loadFontForLanguage(settings.uiLanguage);
-    loadFontForLanguage(settings.language);
-    if (settings.translate) loadFontForLanguage(settings.targetLanguage);
-  }, [
-    isHydrated,
-    settings.uiLanguage,
-    settings.language,
-    settings.translate,
-    settings.targetLanguage,
-  ]);
+    loadFontForLanguage(uiLanguage);
+    loadFontForLanguage(language);
+    if (translate) loadFontForLanguage(targetLanguage);
+  }, [isHydrated, uiLanguage, language, translate, targetLanguage]);
 
-  // Whenever settings change, persist them
-  useEffect(() => {
-    async function saveState() {
-      if (!isHydrated || !store) return;
-      try {
-        await store.set("settings", settings);
-        await store.save();
-      } catch (error) {
-        console.error("Error saving state:", error);
-      }
-    }
-
-    saveState();
-  }, [settings, store, isHydrated]);
-
-  // A handy reset function
-  function resetSettings() {
-    setSettings({
-      ...DEFAULT_SETTINGS,
-      uiLanguage: getPreferredUiLanguage(),
-      onboardingCompleted: true,
-      // Preserve milestone tracking and usage data
-      transcriptionsCompleted: settings.transcriptionsCompleted,
-      subSlateMilestoneShown: settings.subSlateMilestoneShown,
-      timesDismissedSurvey: settings.timesDismissedSurvey,
-      lastSurveyDate: settings.lastSurveyDate,
-      lastSeenVersion: settings.lastSeenVersion,
-    });
-  }
-
-  // Update a setting
-  // This enforces that key is a valid Settings property, and value must match its type
-  function updateSetting<K extends keyof Settings>(key: K, value: Settings[K]) {
-    setSettings((prev) => {
-      const newSettings = {
-        ...prev,
-        [key]:
-          key === "uiLanguage" ? normalizeUiLanguage(value as string) : value,
-      };
-
-      // Check if language changed and current model supports the new language
-      if (key === "language" && value !== prev.language) {
-        const currentModel = models[prev.model];
-        if (!modelSupportsLanguage(currentModel, value as string)) {
-          // Find first recommended model that supports the new language
-          const recommendedModel = getFirstRecommendedModelForLanguage(
-            value as string,
-          );
-          if (recommendedModel) {
-            const modelIndex = models.findIndex(
-              (m) => m.value === recommendedModel.value,
-            );
-            if (modelIndex !== -1) {
-              newSettings.model = modelIndex;
-            }
-          }
-        }
-      }
-
-      return newSettings;
-    });
-  }
+  if (!isHydrated) return null;
 
   return (
-    <SettingsContext.Provider
-      value={{
-        settings,
-        updateSetting,
-        resetSettings,
-        isHydrated,
-      }}
+    <div
+      className="h-screen w-screen bg-background transition-opacity duration-200"
+      style={{ opacity: shouldShowChildren ? 1 : 0 }}
     >
-      {isHydrated ? (
-        <div
-          className="h-screen w-screen bg-background transition-opacity duration-200"
-          style={{ opacity: shouldShowChildren ? 1 : 0 }}
-        >
-          {children}
-        </div>
-      ) : null}
-    </SettingsContext.Provider>
+      {children}
+    </div>
   );
 }
-
-export const useSettings = () => {
-  const context = useContext(SettingsContext);
-  if (!context) {
-    throw new Error("useSettings must be used within a SettingsProvider");
-  }
-  return context;
-};
-
-export type { Settings };

--- a/AutoSubs-App/src/contexts/SettingsContext.tsx
+++ b/AutoSubs-App/src/contexts/SettingsContext.tsx
@@ -80,7 +80,11 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
     requestAnimationFrame(() => setShouldShowChildren(true));
   }, [isHydrated]);
 
-  // Re-initialise i18n when the UI language changes.
+  // Re-initialise i18n when the UI language changes at runtime (e.g. via the
+  // settings dialog). The initial i18n setup happens inside
+  // hydrateSettingsStore() before isHydrated flips to true, so children first
+  // render with the correct language; this effect only handles subsequent
+  // changes.
   const uiLanguage = useSettingsStore((s) => s.uiLanguage);
   useEffect(() => {
     if (!isHydrated) return;

--- a/AutoSubs-App/src/lib/tauri-storage.ts
+++ b/AutoSubs-App/src/lib/tauri-storage.ts
@@ -1,0 +1,70 @@
+import { load, Store } from "@tauri-apps/plugin-store";
+import type { PersistStorage, StorageValue } from "zustand/middleware";
+
+/**
+ * Cache of loaded Tauri `Store` instances, keyed by file path.
+ *
+ * The Tauri plugin-store backend keys stores by path, so multiple `load()`
+ * calls with the same path share the same underlying Rust store. We cache the
+ * JS wrapper to avoid creating redundant resource-table entries.
+ */
+const storeCache = new Map<string, Store>();
+
+async function getStore(path: string): Promise<Store> {
+  let store = storeCache.get(path);
+  if (!store) {
+    store = await load(path, { autoSave: false });
+    storeCache.set(path, store);
+  }
+  return store;
+}
+
+/**
+ * Check whether a key exists in the Tauri store file. Used during manual
+ * rehydration to detect first-run (no persisted data) vs. returning users.
+ */
+export async function hasStoredValue(path: string, key: string): Promise<boolean> {
+  const store = await getStore(path);
+  return store.has(key);
+}
+
+/**
+ * Create a zustand `PersistStorage` backed by the official Tauri plugin-store.
+ *
+ * Unlike `createJSONStorage` (which stores a JSON string), this adapter stores
+ * the raw state object directly under `key` in the Tauri store file —
+ * preserving the existing on-disk format so current users' settings files
+ * continue to work without migration.
+ *
+ * The `StorageValue` wrapper (`{ state, version }`) that zustand's persist
+ * middleware uses internally is unwrapped: only `value.state` is written to
+ * disk, and on read the persisted object is re-wrapped as
+ * `{ state: <obj>, version: 0 }`.
+ *
+ * @param path - Tauri store file name (e.g. `"autosubs-store.json"`)
+ * @param key - Key under which the state is stored within the file
+ */
+export function createTauriStorage<T>(
+  path: string,
+  key: string,
+): PersistStorage<T> {
+  return {
+    getItem: async () => {
+      const store = await getStore(path);
+      const value = await store.get<T>(key);
+      if (value == null) return null;
+      return { state: value, version: 0 } as StorageValue<T>;
+    },
+    setItem: async (_name, value) => {
+      const store = await getStore(path);
+      // Unwrap StorageValue — store only the state to preserve file format.
+      await store.set(key, value.state);
+      await store.save();
+    },
+    removeItem: async () => {
+      const store = await getStore(path);
+      await store.delete(key);
+      await store.save();
+    },
+  };
+}

--- a/AutoSubs-App/src/stores/settings-store.ts
+++ b/AutoSubs-App/src/stores/settings-store.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { platform } from "@tauri-apps/plugin-os";
 import { Settings } from "@/types";
-import { getPreferredUiLanguage, normalizeUiLanguage } from "@/i18n";
+import { getPreferredUiLanguage, normalizeUiLanguage, initI18n } from "@/i18n";
 import {
   models,
   modelSupportsLanguage,
@@ -192,6 +192,13 @@ export async function hydrateSettingsStore(): Promise<void> {
     // Trigger persist's rehydration (zustand merges persisted state over
     // the current in-memory state).
     await useSettingsStore.persist.rehydrate();
+
+    // Initialise i18n with the hydrated UI language *before* marking the
+    // store as hydrated. SettingsProvider gates children on isHydrated, so
+    // this guarantees the first render of children uses the correct language
+    // and avoids a one-frame flash of the default (en) UI for returning
+    // non-English users.
+    initI18n(useSettingsStore.getState().uiLanguage);
   } catch (error) {
     console.error("Error initializing settings store:", error);
   } finally {

--- a/AutoSubs-App/src/stores/settings-store.ts
+++ b/AutoSubs-App/src/stores/settings-store.ts
@@ -1,0 +1,200 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { platform } from "@tauri-apps/plugin-os";
+import { Settings } from "@/types";
+import { getPreferredUiLanguage, normalizeUiLanguage } from "@/i18n";
+import {
+  models,
+  modelSupportsLanguage,
+  getFirstRecommendedModelForLanguage,
+} from "@/lib/models";
+import { DEFAULT_PRESET_ID } from "@/presets/built-in-presets";
+import { createTauriStorage, hasStoredValue } from "@/lib/tauri-storage";
+
+// ─── Store file config ────────────────────────────────────────────────────
+// Same file + key as the previous SettingsContext so existing user data
+// continues to load without migration.
+const STORE_FILE = "autosubs-store.json";
+const STORE_KEY = "settings";
+
+// ─── Default settings ─────────────────────────────────────────────────────
+export const DEFAULT_SETTINGS: Settings = {
+  // Mode
+  audioInputMode: "timeline",
+  preferredEditorIntegration: "davinci",
+
+  // UI settings
+  uiLanguage: "en",
+  onboardingCompleted: false,
+  tourCompleted: false,
+  lastSeenVersion: "",
+  showEnglishOnlyModels: false,
+
+  // Survey notification settings
+  timesDismissedSurvey: 0,
+  lastSurveyDate: new Date().toISOString(),
+
+  // Milestone tracking
+  transcriptionsCompleted: 0,
+  subSlateMilestoneShown: false,
+
+  // Processing settings
+  model: 0,
+  language: "auto",
+  translate: false,
+  targetLanguage: "en",
+  enableDTW: true, // gpu enabled by default on mac and linux, disabled by default on windows
+  enableGpu: true,
+  enableDiarize: false,
+  maxSpeakers: null,
+  exportRange: "inout",
+
+  // Text settings
+  textDensity: "standard",
+  maxLinesPerSubtitle: 1,
+  splitOnPunctuation: true,
+  textCase: "none",
+  removePunctuation: false,
+  enableCensor: false,
+  censoredWords: [],
+  activeCensorLists: [],
+  customPrompt: "",
+  customMaxCharsPerLine: 38,
+
+  // Resolve settings
+  selectedInputTracksByApp: {
+    davinci: ["1"],
+    premiere: [],
+    aftereffects: [],
+  },
+  selectedOutputTrack: "1",
+  selectedTemplate: { value: "Default Template", label: "Default Template" },
+
+  // AutoSubs Caption settings
+  presetId: DEFAULT_PRESET_ID,
+  captionMode: "animated",
+
+  // Animation settings
+  animationType: "none",
+  highlightType: "none",
+  highlightColor: "#000000",
+};
+
+// ─── Store type ───────────────────────────────────────────────────────────
+interface SettingsStore extends Settings {
+  /** Whether the store has finished loading from disk. */
+  isHydrated: boolean;
+
+  // Actions
+  updateSetting: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
+  resetSettings: () => void;
+  /** Mark the store as hydrated. */
+  setHydrated: () => void;
+}
+
+// ─── Store creation ───────────────────────────────────────────────────────
+export const useSettingsStore = create<SettingsStore>()(
+  persist(
+    (set) => ({
+      ...DEFAULT_SETTINGS,
+      isHydrated: false,
+
+      updateSetting: (key, value) =>
+        set((state) => {
+          const patch: Partial<Settings> = {
+            [key]:
+              key === "uiLanguage"
+                ? (normalizeUiLanguage(value as string) as Settings[typeof key])
+                : value,
+          };
+
+          // If language changed and the current model doesn't support it,
+          // auto-switch to the first recommended model that does.
+          if (key === "language" && value !== state.language) {
+            const currentModel = models[state.model];
+            if (!modelSupportsLanguage(currentModel, value as string)) {
+              const recommended = getFirstRecommendedModelForLanguage(value as string);
+              if (recommended) {
+                const idx = models.findIndex((m) => m.value === recommended.value);
+                if (idx !== -1) patch.model = idx;
+              }
+            }
+          }
+
+          return patch;
+        }),
+
+      resetSettings: () =>
+        set((state) => ({
+          ...DEFAULT_SETTINGS,
+          uiLanguage: getPreferredUiLanguage(),
+          onboardingCompleted: true,
+          // Preserve milestone tracking and usage data
+          transcriptionsCompleted: state.transcriptionsCompleted,
+          subSlateMilestoneShown: state.subSlateMilestoneShown,
+          timesDismissedSurvey: state.timesDismissedSurvey,
+          lastSurveyDate: state.lastSurveyDate,
+          lastSeenVersion: state.lastSeenVersion,
+        })),
+
+      setHydrated: () => set({ isHydrated: true }),
+    }),
+    {
+      name: STORE_KEY,
+      storage: createTauriStorage<Settings>(STORE_FILE, STORE_KEY),
+      // Only persist the settings fields — never the hydration flag or actions.
+      partialize: (state) => {
+        const {
+          isHydrated,
+          updateSetting,
+          resetSettings,
+          setHydrated,
+          ...settings
+        } = state;
+        return settings;
+      },
+      // We handle rehydration manually in SettingsProvider so we can detect
+      // first-run (for platform-specific enableDTW default) before loading.
+      skipHydration: true,
+    },
+  ),
+);
+
+// ─── Manual rehydration ───────────────────────────────────────────────────
+/**
+ * Load settings from the Tauri store, applying platform-specific defaults
+ * on first run. This mirrors the previous SettingsContext init flow:
+ *
+ * 1. Detect platform (for Windows enableDTW default on first run).
+ * 2. Check whether persisted data exists.
+ * 3. If first run, apply platform-specific defaults before rehydration.
+ * 4. Rehydrate from storage (zustand's default merge spreads persisted
+ *    fields over the in-memory defaults).
+ * 5. Mark as hydrated.
+ */
+export async function hydrateSettingsStore(): Promise<void> {
+  try {
+    const currentPlatform = await platform();
+    const isWindows = currentPlatform === "windows";
+
+    const hasData = await hasStoredValue(STORE_FILE, STORE_KEY);
+
+    if (!hasData) {
+      // First run — apply platform-specific defaults that differ from
+      // DEFAULT_SETTINGS. With no persisted data, zustand's default merge
+      // keeps these values as-is.
+      useSettingsStore.setState({
+        enableDTW: !isWindows,
+        uiLanguage: getPreferredUiLanguage(),
+      });
+    }
+
+    // Trigger persist's rehydration (zustand merges persisted state over
+    // the current in-memory state).
+    await useSettingsStore.persist.rehydrate();
+  } catch (error) {
+    console.error("Error initializing settings store:", error);
+  } finally {
+    useSettingsStore.getState().setHydrated();
+  }
+}


### PR DESCRIPTION
## Summary
- Migrates settings state management from a React Context (`SettingsContext`) to a global Zustand store (`useSettingsStore`) with `persist` middleware backed by a Tauri storage adapter, enabling fine-grained selector-based reactivity.
- Converts all 22 `useSettings()` consumers (3 provider-tree contexts + 19 components) to read individual fields via selectors, using `useShallow` for field groups and `useSettingsStore.getState()` for non-reactive access inside callbacks/effects.
- Retains `SettingsContext.tsx` as a thin backward-compatible shim (`useSettings()` + `SettingsProvider`) so the provider tree, manual rehydration, i18n init, and font-loading side-effects are preserved.
- Removes legacy field migrations (`selectedInputTracks` → `selectedInputTracksByApp`, `isStandaloneMode` → `audioInputMode`, `uiLanguage` renormalization), the custom persist `merge` function, and the unused `setSettings` action — zustand's default merge over `DEFAULT_SETTINGS` is sufficient.

### Why
The previous Context re-rendered all 22 consumers on any settings change. The Zustand store lets each component subscribe to exactly the fields it reads, so a change to e.g. `diarize` no longer re-renders the language selector. Persisted data continues to load from the same `autosubs-store.json` / `settings` key, so no user-facing migration is required for current fields.

### Tradeoffs
- Net +~300 lines from new store infrastructure, the Tauri storage adapter, and increased selector verbosity, traded for materially fewer re-renders.
- Users on very old configs carrying the legacy `selectedInputTracks` / `isStandaloneMode` fields will now get defaults for `selectedInputTracksByApp` / `audioInputMode` instead of migrated values. Acceptable per discussion — losing those legacy configs is not a concern.

#### Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] App launches and settings hydrate from existing `autosubs-store.json`
- [ ] First-run onboarding flow still applies platform-specific `enableDTW` default (off on Windows)
- [ ] Changing a single setting (e.g. `diarize`) does not re-render unrelated consumers
- [ ] Settings dialog reset (`resetSettings`) restores defaults
- [ ] UI language change re-initializes i18n
- [ ] Resolve / Adobe integrations still receive up-to-date settings