### PR TITLE
feat: add optional MMS forced alignment for word timestamps

### DIFF
--- a/AutoSubs-App/models.json
+++ b/AutoSubs-App/models.json
@@ -267,5 +267,30 @@
     "repo": "altunenes/speaker-diarization-community-1-onnx",
     "files": ["segmentation-community-1.onnx", "embedding_model.onnx"],
     "ui": { "size": "40MB", "ram": "", "image": "diarize.png", "accuracy": 3, "weight": 3, "languageSupport": { "kind": "multilingual" } }
+  },
+  "_aligner_comment": "Optional MMS forced-alignment model, downloaded separately under CC BY-NC 4.0.",
+  "aligner": {
+    "id": "mms-forced-aligner",
+    "repo": "onnx-community/mms-300m-1130-forced-aligner-ONNX",
+    "files": [
+      "onnx/model_int8.onnx",
+      "vocab.json",
+      "config.json",
+      "preprocessor_config.json"
+    ],
+    "license": {
+      "spdx": "CC-BY-NC-4.0",
+      "url": "https://creativecommons.org/licenses/by-nc/4.0/",
+      "attribution": "Meta MMS forced-alignment model; upstream conversion by MahmoudAshraf; ONNX conversion by onnx-community",
+      "commercialUse": false
+    },
+    "ui": {
+      "size": "317MB",
+      "ram": "1GB",
+      "image": "diarize.png",
+      "accuracy": 4,
+      "weight": 1,
+      "languageSupport": { "kind": "multilingual" }
+    }
   }
 }

--- a/AutoSubs-App/src-tauri/Cargo.lock
+++ b/AutoSubs-App/src-tauri/Cargo.lock
@@ -855,6 +855,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,7 +904,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf",
+ "phf 0.13.1",
  "smallvec",
 ]
 
@@ -3193,6 +3212,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3526,6 +3557,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3731,13 +3771,32 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.13.1",
  "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -3746,8 +3805,18 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3757,7 +3826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -3766,11 +3835,20 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -4180,6 +4258,26 @@ name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -4693,8 +4791,8 @@ dependencies = [
  "derive_more",
  "log",
  "new_debug_unreachable",
- "phf",
- "phf_codegen",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
  "precomputed-hash",
  "rustc-hash 2.1.2",
  "servo_arc",
@@ -4766,9 +4864,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -5099,7 +5197,7 @@ checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.13.1",
  "precomputed-hash",
 ]
 
@@ -5109,8 +5207,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
 ]
@@ -5767,7 +5865,7 @@ dependencies = [
  "json-patch",
  "log",
  "memchr",
- "phf",
+ "phf 0.13.1",
  "plist",
  "proc-macro2",
  "quote",
@@ -6292,7 +6390,9 @@ dependencies = [
  "futures",
  "hf-hub",
  "hound",
+ "ndarray 0.16.1",
  "once_cell",
+ "ort",
  "regex",
  "reqwest 0.11.27",
  "serde",
@@ -6301,7 +6401,9 @@ dependencies = [
  "tokio-util",
  "tracing",
  "transcribe-rs",
+ "unicode-normalization",
  "unicode-segmentation",
+ "uroman",
  "whisper-rs",
  "zip 4.6.1",
 ]
@@ -6451,6 +6553,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6467,6 +6584,26 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_names2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d189085656ca1203291e965444e7f6a2723fbdd1dd9f34f8482e79bafd8338a0"
+dependencies = [
+ "phf 0.11.3",
+ "unicode_names2_generator",
+]
+
+[[package]]
+name = "unicode_names2_generator"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1262662dc96937c71115228ce2e1d30f41db71a7a45d3459e98783ef94052214"
+dependencies = [
+ "phf_codegen 0.11.3",
+ "rand 0.8.6",
+]
 
 [[package]]
 name = "unit-prefix"
@@ -6539,6 +6676,26 @@ dependencies = [
  "serde",
  "unic-ucd-ident",
  "url",
+]
+
+[[package]]
+name = "uroman"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4cd57e909129ad42583f9f3c4705620db3ea86c878e5d6c7e7ba80be419dc9d"
+dependencies = [
+ "num-rational",
+ "ordered-float",
+ "phf 0.13.1",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "unicode-normalization",
+ "unicode-properties",
+ "unicode-segmentation",
+ "unicode_names2",
 ]
 
 [[package]]
@@ -6875,8 +7032,8 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
 dependencies = [
- "phf",
- "phf_codegen",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
  "string_cache",
  "string_cache_codegen",
 ]

--- a/AutoSubs-App/src-tauri/crates/transcription-engine/Cargo.toml
+++ b/AutoSubs-App/src-tauri/crates/transcription-engine/Cargo.toml
@@ -25,11 +25,16 @@ futures = "0.3"
 tokio = { version = "1", features = ["time", "macros", "rt-multi-thread", "sync"] }
 tokio-util = "0.7"
 unicode-segmentation = "1.11"
+ort = { version = "=2.0.0-rc.12", features = ["ndarray"] }
+ndarray = "0.16"
+uroman = "0.6.5"
+unicode-normalization = "0.1"
 
 [features]
-coreml = ["whisper-rs/coreml", "diarize/coreml"]
-directml = ["diarize/directml"]
-cuda = ["whisper-rs/cuda", "diarize/load-dynamic"]
+coreml = ["whisper-rs/coreml", "diarize/coreml", "ort/coreml"]
+directml = ["diarize/directml", "ort/directml"]
+load-dynamic = ["ort/load-dynamic"]
+cuda = ["whisper-rs/cuda", "diarize/load-dynamic", "load-dynamic"]
 openblas = ["whisper-rs/openblas"]
 metal = ["whisper-rs/metal"]
 rocm = ["whisper-rs/hipblas"]
@@ -37,7 +42,7 @@ vulkan = ["whisper-rs/vulkan"]
 
 # Platform/arch presets
 mac-aarch = ["coreml", "metal"]
-mac-x86_64 = ["metal", "diarize/load-dynamic"]
+mac-x86_64 = ["metal", "diarize/load-dynamic", "load-dynamic"]
 windows = ["vulkan", "directml"]  # Whisper GPU via Vulkan + Pyannote via DirectML (requires Vulkan SDK: https://vulkan.lunarg.com)
 linux = ["vulkan"]
 

--- a/AutoSubs-App/src-tauri/crates/transcription-engine/examples/progress.rs
+++ b/AutoSubs-App/src-tauri/crates/transcription-engine/examples/progress.rs
@@ -5,6 +5,7 @@ use transcription_engine::{Callbacks, Engine, EngineConfig, ProgressType, Transc
 static DOWNLOAD_COUNT: AtomicU32 = AtomicU32::new(0);
 static DIARIZE_COUNT: AtomicU32 = AtomicU32::new(0);
 static TRANSCRIBE_COUNT: AtomicU32 = AtomicU32::new(0);
+static ALIGN_COUNT: AtomicU32 = AtomicU32::new(0);
 static TRANSLATE_COUNT: AtomicU32 = AtomicU32::new(0);
 
 struct CliArgs {
@@ -87,6 +88,10 @@ fn on_progress(percent: i32, progress_type: ProgressType, label: &str) {
         ProgressType::Transcribe => {
             let count = TRANSCRIBE_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
             println!("[TRANSCRIBE #{count}] {percent}%: {label}");
+        }
+        ProgressType::Align => {
+            let count = ALIGN_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
+            println!("[ALIGN #{count}] {percent}%: {label}");
         }
         ProgressType::Translate => {
             let count = TRANSLATE_COUNT.fetch_add(1, Ordering::Relaxed) + 1;

--- a/AutoSubs-App/src-tauri/crates/transcription-engine/examples/transcribe.rs
+++ b/AutoSubs-App/src-tauri/crates/transcription-engine/examples/transcribe.rs
@@ -117,6 +117,7 @@ fn on_progress(percent: i32, progress_type: ProgressType, label: &str) {
         ProgressType::Download => "📥",
         ProgressType::Diarize => "🗣️",
         ProgressType::Transcribe => "🎵",
+        ProgressType::Align => "⏱️",
         ProgressType::Translate => "🌍",
     };
     println!("{prefix} {label}: {percent}%");

--- a/AutoSubs-App/src-tauri/crates/transcription-engine/src/align.rs
+++ b/AutoSubs-App/src-tauri/crates/transcription-engine/src/align.rs
@@ -203,7 +203,9 @@ impl Aligner {
             bail!("stitched logits are not rectangular");
         }
         if extension > 0 {
-            let trim = extension / INPUTS_TO_LOGITS_RATIO;
+            // Round up so any frame that contains a padded sample is discarded,
+            // preventing CTC from placing a word boundary beyond the real audio slice.
+            let trim = extension.div_ceil(INPUTS_TO_LOGITS_RATIO);
             frames = frames
                 .checked_sub(trim)
                 .context("final extension exceeds generated frames")?;

--- a/AutoSubs-App/src-tauri/crates/transcription-engine/src/align.rs
+++ b/AutoSubs-App/src-tauri/crates/transcription-engine/src/align.rs
@@ -1,0 +1,1236 @@
+use crate::types::WordTimestamp;
+use eyre::{Context, ContextCompat, Result, bail, eyre};
+use ndarray::{Array2, ArrayView2, s};
+use ort::session::Session;
+use ort::session::builder::GraphOptimizationLevel;
+use ort::value::{Tensor, ValueType};
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::Path;
+use unicode_normalization::{UnicodeNormalization, char::is_combining_mark};
+use uroman::{Uroman, rom_format};
+
+const SAMPLE_RATE: usize = 16_000;
+const INPUTS_TO_LOGITS_RATIO: usize = 320;
+const WINDOW_SAMPLES: usize = 30 * SAMPLE_RATE;
+const CONTEXT_SAMPLES: usize = 2 * SAMPLE_RATE;
+const FRAME_SECONDS: f64 = INPUTS_TO_LOGITS_RATIO as f64 / SAMPLE_RATE as f64;
+const MODEL_CLASSES: usize = 31;
+const MAX_DP_BYTES: usize = 512 * 1024 * 1024;
+
+type Cancellation<'a> = Option<&'a (dyn Fn() -> bool + Send + Sync)>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AlignmentUnit {
+    pub original_text: String,
+    pub normalized_tokens: Vec<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AlignmentPath {
+    pub labels: Vec<usize>,
+    pub scores: Vec<f32>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TokenSegment {
+    pub label: usize,
+    pub start: usize,
+    pub end: usize,
+    pub score: f32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AlignmentSpan {
+    pub start: usize,
+    pub end: usize,
+    pub score: f32,
+}
+
+pub struct Aligner {
+    session: Session,
+    vocabulary: HashMap<String, usize>,
+    blank_id: usize,
+    star_id: usize,
+    sample_rate: usize,
+    inputs_to_logits_ratio: usize,
+    do_normalize: bool,
+    uroman: Uroman,
+}
+
+impl Aligner {
+    pub fn load(model_dir: impl AsRef<Path>) -> Result<Self> {
+        let model_dir = model_dir.as_ref();
+        let vocabulary = load_vocabulary(&model_dir.join("vocab.json"))?;
+        let blank_id = vocabulary
+            .get("<blank>")
+            .copied()
+            .context("vocab.json does not contain <blank>")?;
+        if blank_id >= vocabulary.len() {
+            bail!("blank token ID {blank_id} is outside the vocabulary");
+        }
+        let star_id = vocabulary.len();
+
+        let config = read_json(&model_dir.join("config.json"))?;
+        let ratio = config_ratio(&config)?;
+        if ratio != INPUTS_TO_LOGITS_RATIO {
+            bail!("unsupported inputs_to_logits_ratio {ratio}; expected {INPUTS_TO_LOGITS_RATIO}");
+        }
+
+        let preprocessor = read_json(&model_dir.join("preprocessor_config.json"))?;
+        let sample_rate = json_usize(&preprocessor, "sampling_rate")?;
+        if sample_rate != SAMPLE_RATE {
+            bail!("unsupported model sample rate {sample_rate}; expected {SAMPLE_RATE}");
+        }
+        let do_normalize = preprocessor
+            .get("do_normalize")
+            .and_then(Value::as_bool)
+            .context("preprocessor_config.json is missing boolean do_normalize")?;
+        if !do_normalize {
+            bail!("model preprocessor must enable waveform normalization");
+        }
+
+        let model_path = model_dir.join("onnx/model_int8.onnx");
+        let session = Session::builder()
+            .map_err(|error| eyre!("failed to create ONNX session builder: {error}"))?
+            .with_optimization_level(GraphOptimizationLevel::Level3)
+            .map_err(|error| eyre!("failed to set ONNX optimization level: {error}"))?
+            .with_intra_threads(1)
+            .map_err(|error| eyre!("failed to set ONNX intra-op threads: {error}"))?
+            .with_inter_threads(1)
+            .map_err(|error| eyre!("failed to set ONNX inter-op threads: {error}"))?
+            .commit_from_file(&model_path)
+            .map_err(|error| eyre!("failed to load {}: {error}", model_path.display()))?;
+        validate_session(&session, vocabulary.len())?;
+
+        Ok(Self {
+            session,
+            vocabulary,
+            blank_id,
+            star_id,
+            sample_rate,
+            inputs_to_logits_ratio: ratio,
+            do_normalize,
+            uroman: Uroman::new(),
+        })
+    }
+
+    pub fn blank_id(&self) -> usize {
+        self.blank_id
+    }
+
+    pub fn star_id(&self) -> usize {
+        self.star_id
+    }
+
+    pub fn vocabulary(&self) -> &HashMap<String, usize> {
+        &self.vocabulary
+    }
+
+    pub fn generate_emissions(
+        &mut self,
+        samples: &[f32],
+        cancellation: Cancellation<'_>,
+    ) -> Result<Array2<f32>> {
+        if samples.is_empty() {
+            bail!("cannot generate emissions for empty audio");
+        }
+        if samples.iter().any(|sample| !sample.is_finite()) {
+            bail!("audio contains non-finite samples");
+        }
+        if self.sample_rate != SAMPLE_RATE
+            || self.inputs_to_logits_ratio != INPUTS_TO_LOGITS_RATIO
+            || !self.do_normalize
+        {
+            bail!("aligner preprocessing metadata is inconsistent");
+        }
+
+        let mut chunks = Vec::new();
+        let mut extension = 0usize;
+        let chunked = samples.len() >= WINDOW_SAMPLES;
+        if chunked {
+            let windows = samples
+                .len()
+                .checked_add(WINDOW_SAMPLES - 1)
+                .context("audio length overflow")?
+                / WINDOW_SAMPLES;
+            let padded_len = windows
+                .checked_mul(WINDOW_SAMPLES)
+                .and_then(|length| length.checked_add(2 * CONTEXT_SAMPLES))
+                .context("padded audio length overflow")?;
+            extension = windows * WINDOW_SAMPLES - samples.len();
+            let mut padded = vec![0.0; padded_len];
+            let end = CONTEXT_SAMPLES
+                .checked_add(samples.len())
+                .context("audio copy range overflow")?;
+            padded[CONTEXT_SAMPLES..end].copy_from_slice(samples);
+            let chunk_len = WINDOW_SAMPLES + 2 * CONTEXT_SAMPLES;
+            for index in 0..windows {
+                let start = index * WINDOW_SAMPLES;
+                let end = start + chunk_len;
+                chunks.push(padded[start..end].to_vec());
+            }
+        } else {
+            chunks.push(samples.to_vec());
+        }
+
+        let context_frames = CONTEXT_SAMPLES / INPUTS_TO_LOGITS_RATIO;
+        let window_frames = WINDOW_SAMPLES / INPUTS_TO_LOGITS_RATIO;
+        let mut retained = Vec::new();
+        for chunk in chunks {
+            check_cancelled(cancellation)?;
+            let logits = self.run_chunk(&chunk)?;
+            let (start, end) = if chunked {
+                let end = context_frames
+                    .checked_add(window_frames)
+                    .context("frame trim range overflow")?;
+                if logits.nrows() < end {
+                    bail!(
+                        "model returned {} frames, fewer than required chunk trim endpoint {end}",
+                        logits.nrows()
+                    );
+                }
+                (context_frames, end)
+            } else {
+                (0, logits.nrows())
+            };
+            retained.extend(logits.slice(s![start..end, ..]).iter().copied());
+        }
+
+        let mut frames = retained.len() / MODEL_CLASSES;
+        if retained.len() % MODEL_CLASSES != 0 {
+            bail!("stitched logits are not rectangular");
+        }
+        if extension > 0 {
+            let trim = extension / INPUTS_TO_LOGITS_RATIO;
+            frames = frames
+                .checked_sub(trim)
+                .context("final extension exceeds generated frames")?;
+            retained.truncate(frames * MODEL_CLASSES);
+        }
+        let logits = Array2::from_shape_vec((frames, MODEL_CLASSES), retained)
+            .context("failed to shape stitched logits")?;
+        augment_log_probs(logits.view(), self.star_id)
+    }
+
+    pub fn prepare_text(&self, text: &str, language: Option<&str>) -> Result<Vec<AlignmentUnit>> {
+        prepare_text_with(&self.uroman, &self.vocabulary, text, language)
+    }
+
+    pub fn align_words(
+        &mut self,
+        samples: &[i16],
+        text: &str,
+        language: Option<&str>,
+        cancellation: Cancellation<'_>,
+    ) -> Result<Vec<WordTimestamp>> {
+        check_cancelled(cancellation)?;
+        let normalized = normalize_samples(samples);
+        if normalized.is_empty() {
+            bail!("cannot align empty audio");
+        }
+        let units = self.prepare_text(text, language)?;
+        let (targets, unit_ranges) = build_targets(&units, self.star_id)?;
+        let emissions = self.generate_emissions(&normalized, cancellation)?;
+        let path = forced_align(emissions.view(), &targets, self.blank_id, cancellation)?;
+        let segments = merge_repeats(&path)?;
+        let spans = get_spans(&targets, &segments, self.blank_id)?;
+        if spans.len() != targets.len() {
+            bail!(
+                "alignment produced {} spans for {} targets",
+                spans.len(),
+                targets.len()
+            );
+        }
+
+        let mut words = Vec::with_capacity(units.len());
+        for (unit, range) in units.iter().zip(unit_ranges) {
+            let selected = spans
+                .get(range.clone())
+                .context("unit span range is outside aligned targets")?;
+            let start = selected
+                .first()
+                .context("alignment unit has no spans")?
+                .start;
+            let end = selected.last().context("alignment unit has no spans")?.end;
+            let score_sum: f32 = selected.iter().map(|span| span.score).sum();
+            let probability = (score_sum / selected.len() as f32).exp().clamp(0.0, 1.0);
+            words.push(WordTimestamp {
+                text: unit.original_text.clone(),
+                start: start as f64 * FRAME_SECONDS,
+                end: end as f64 * FRAME_SECONDS,
+                probability: Some(probability),
+            });
+        }
+        Ok(words)
+    }
+
+    fn run_chunk(&mut self, samples: &[f32]) -> Result<Array2<f32>> {
+        let tensor = Tensor::from_array(([1usize, samples.len()], samples.to_vec()))
+            .map_err(|error| eyre!("failed to prepare input_values: {error}"))?;
+        let outputs = self
+            .session
+            .run(ort::inputs!["input_values" => tensor])
+            .map_err(|error| eyre!("ONNX aligner inference failed: {error}"))?;
+        let output = outputs
+            .get("logits")
+            .or_else(|| outputs.get("output_0"))
+            .context("ONNX aligner output 'logits' was not found")?;
+        let (shape, data) = output
+            .try_extract_tensor::<f32>()
+            .map_err(|error| eyre!("failed to extract aligner logits: {error}"))?;
+        if shape.len() != 3 || shape[0] != 1 || shape[2] != MODEL_CLASSES as i64 {
+            bail!("expected logits shape [1,T,{MODEL_CLASSES}], got {shape:?}");
+        }
+        let frames =
+            usize::try_from(shape[1]).context("negative or oversized logits frame count")?;
+        let expected = frames
+            .checked_mul(MODEL_CLASSES)
+            .context("logits element count overflow")?;
+        if data.len() != expected {
+            bail!("logits contain {} values, expected {expected}", data.len());
+        }
+        if data.iter().any(|value| !value.is_finite()) {
+            bail!("model returned non-finite logits");
+        }
+        Array2::from_shape_vec((frames, MODEL_CLASSES), data.to_vec())
+            .context("failed to shape model logits")
+    }
+}
+
+pub fn load_vocabulary(path: &Path) -> Result<HashMap<String, usize>> {
+    let value = read_json(path)?;
+    let object = value
+        .as_object()
+        .context("vocab.json must contain a token-to-ID object")?;
+    if object.len() != MODEL_CLASSES {
+        bail!(
+            "vocab.json contains {} entries; expected {MODEL_CLASSES}",
+            object.len()
+        );
+    }
+    let mut vocabulary = HashMap::with_capacity(object.len());
+    let mut ids = HashSet::with_capacity(object.len());
+    for (token, value) in object {
+        let raw = value
+            .as_u64()
+            .ok_or_else(|| eyre!("vocabulary ID for {token:?} is not an unsigned integer"))?;
+        let id = usize::try_from(raw).context("vocabulary ID does not fit usize")?;
+        if id >= MODEL_CLASSES {
+            bail!("vocabulary ID {id} for {token:?} is outside 0..{MODEL_CLASSES}");
+        }
+        if !ids.insert(id) {
+            bail!("duplicate vocabulary ID {id}");
+        }
+        let normalized_token = token.to_lowercase();
+        if vocabulary.insert(normalized_token.clone(), id).is_some() {
+            bail!("duplicate vocabulary token after lowercasing: {normalized_token:?}");
+        }
+    }
+    if vocabulary.len() != MODEL_CLASSES
+        || ids.len() != MODEL_CLASSES
+        || !(0..MODEL_CLASSES).all(|id| ids.contains(&id))
+    {
+        bail!("vocabulary IDs must cover every value in 0..{MODEL_CLASSES}");
+    }
+    Ok(vocabulary)
+}
+
+pub fn normalize_samples(samples: &[i16]) -> Vec<f32> {
+    if samples.is_empty() {
+        return Vec::new();
+    }
+    let mut normalized: Vec<f32> = samples
+        .iter()
+        .map(|sample| *sample as f32 / 32768.0)
+        .collect();
+    let mean = normalized.iter().map(|value| *value as f64).sum::<f64>() / normalized.len() as f64;
+    let variance = normalized
+        .iter()
+        .map(|value| {
+            let difference = *value as f64 - mean;
+            difference * difference
+        })
+        .sum::<f64>()
+        / normalized.len() as f64;
+    let denominator = (variance + 1e-7).sqrt() as f32;
+    for value in &mut normalized {
+        *value = (*value - mean as f32) / denominator;
+    }
+    normalized
+}
+
+pub fn log_softmax(logits: ArrayView2<'_, f32>) -> Result<Array2<f32>> {
+    if logits.nrows() == 0 || logits.ncols() == 0 {
+        bail!("logits must have non-empty frame and class dimensions");
+    }
+    if logits.iter().any(|value| !value.is_finite()) {
+        bail!("logits contain non-finite values");
+    }
+    let mut result = Array2::zeros(logits.raw_dim());
+    for (mut output, input) in result.rows_mut().into_iter().zip(logits.rows()) {
+        let maximum = input.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+        let sum = input
+            .iter()
+            .map(|value| (*value - maximum).exp())
+            .sum::<f32>();
+        let normalizer = maximum + sum.ln();
+        for (destination, source) in output.iter_mut().zip(input) {
+            *destination = *source - normalizer;
+        }
+    }
+    Ok(result)
+}
+
+pub fn augment_log_probs(logits: ArrayView2<'_, f32>, star_id: usize) -> Result<Array2<f32>> {
+    if star_id != logits.ncols() {
+        bail!(
+            "synthetic star ID {star_id} must equal model class count {}",
+            logits.ncols()
+        );
+    }
+    let normalized = log_softmax(logits)?;
+    let mut emissions = Array2::zeros((normalized.nrows(), normalized.ncols() + 1));
+    emissions.slice_mut(s![.., ..star_id]).assign(&normalized);
+    Ok(emissions)
+}
+
+pub fn forced_align(
+    log_probs: ArrayView2<'_, f32>,
+    targets: &[usize],
+    blank: usize,
+    cancellation: Cancellation<'_>,
+) -> Result<AlignmentPath> {
+    let frames = log_probs.nrows();
+    let classes = log_probs.ncols();
+    if frames == 0 || classes == 0 {
+        bail!("log probabilities must be non-empty");
+    }
+    if log_probs.iter().any(|value| !value.is_finite()) {
+        bail!("log probabilities contain non-finite values");
+    }
+    if targets.is_empty() {
+        bail!("alignment target must not be empty");
+    }
+    if blank >= classes {
+        bail!("blank ID {blank} is outside {classes} classes");
+    }
+    for &target in targets {
+        if target >= classes {
+            bail!("target ID {target} is outside {classes} classes");
+        }
+        if target == blank {
+            bail!("alignment target must not contain blank ID {blank}");
+        }
+    }
+    let repeats = targets.windows(2).filter(|pair| pair[0] == pair[1]).count();
+    let required = targets
+        .len()
+        .checked_add(repeats)
+        .context("target feasibility bound overflow")?;
+    if frames < required {
+        bail!(
+            "{frames} frames cannot align {} targets with {repeats} adjacent repeats",
+            targets.len()
+        );
+    }
+
+    let states = targets
+        .len()
+        .checked_mul(2)
+        .and_then(|value| value.checked_add(1))
+        .context("expanded target state count overflow")?;
+    let backtrace_len = frames
+        .checked_mul(states)
+        .context("alignment workspace size overflow")?;
+    let bytes = backtrace_len
+        .checked_mul(std::mem::size_of::<u8>())
+        .and_then(|value| {
+            value.checked_add(
+                states
+                    .checked_mul(2)?
+                    .checked_mul(std::mem::size_of::<f32>())?,
+            )
+        })
+        .context("alignment workspace byte count overflow")?;
+    if bytes > MAX_DP_BYTES {
+        bail!("alignment workspace requires {bytes} bytes, exceeding {MAX_DP_BYTES} byte limit");
+    }
+    check_cancelled(cancellation)?;
+
+    let mut backtrace = vec![u8::MAX; backtrace_len];
+    let mut previous = vec![f32::NEG_INFINITY; states];
+    let mut current = vec![f32::NEG_INFINITY; states];
+    previous[0] = log_probs[(0, blank)];
+    if states > 1 {
+        previous[1] = log_probs[(0, targets[0])];
+    }
+
+    for frame in 1..frames {
+        if frame & 63 == 0 {
+            check_cancelled(cancellation)?;
+        }
+        current.fill(f32::NEG_INFINITY);
+        let max_state = (2 * frame + 1).min(states - 1);
+        for state in 0..=max_state {
+            let label = if state % 2 == 0 {
+                blank
+            } else {
+                targets[state / 2]
+            };
+            let mut best = previous[state];
+            let mut step = 0u8;
+            if state >= 1 && previous[state - 1] > best {
+                best = previous[state - 1];
+                step = 1;
+            }
+            if state >= 2
+                && state % 2 == 1
+                && targets[state / 2] != targets[state / 2 - 1]
+                && previous[state - 2] > best
+            {
+                best = previous[state - 2];
+                step = 2;
+            }
+            if best.is_finite() {
+                current[state] = best + log_probs[(frame, label)];
+                backtrace[frame * states + state] = step;
+            }
+        }
+        std::mem::swap(&mut previous, &mut current);
+    }
+
+    let last_blank = states - 1;
+    let last_token = states - 2;
+    let mut state = if previous[last_token] >= previous[last_blank] {
+        last_token
+    } else {
+        last_blank
+    };
+    if !previous[state].is_finite() {
+        bail!("no valid CTC alignment path exists");
+    }
+    let mut labels = vec![blank; frames];
+    let mut scores = vec![0.0; frames];
+    for frame in (0..frames).rev() {
+        let label = if state % 2 == 0 {
+            blank
+        } else {
+            targets[state / 2]
+        };
+        labels[frame] = label;
+        scores[frame] = log_probs[(frame, label)];
+        if frame > 0 {
+            let step = backtrace[frame * states + state];
+            if step == u8::MAX || usize::from(step) > state {
+                bail!("invalid CTC traceback at frame {frame}, state {state}");
+            }
+            state -= usize::from(step);
+        }
+    }
+    if state > 1 {
+        bail!("CTC traceback did not reach an initial state");
+    }
+    Ok(AlignmentPath { labels, scores })
+}
+
+pub fn merge_repeats(path: &AlignmentPath) -> Result<Vec<TokenSegment>> {
+    if path.labels.is_empty() || path.labels.len() != path.scores.len() {
+        bail!("alignment path labels and scores must be non-empty and equally sized");
+    }
+    if path.scores.iter().any(|score| !score.is_finite()) {
+        bail!("alignment path contains non-finite scores");
+    }
+    let mut segments = Vec::new();
+    let mut start = 0usize;
+    while start < path.labels.len() {
+        let label = path.labels[start];
+        let mut end = start + 1;
+        while end < path.labels.len() && path.labels[end] == label {
+            end += 1;
+        }
+        let score = path.scores[start..end].iter().sum::<f32>() / (end - start) as f32;
+        segments.push(TokenSegment {
+            label,
+            start,
+            end,
+            score,
+        });
+        start = end;
+    }
+    Ok(segments)
+}
+
+pub fn get_spans(
+    targets: &[usize],
+    segments: &[TokenSegment],
+    blank: usize,
+) -> Result<Vec<AlignmentSpan>> {
+    if targets.is_empty() || segments.is_empty() {
+        bail!("targets and segments must be non-empty");
+    }
+    let mut target_segments = Vec::with_capacity(targets.len());
+    let mut target_index = 0usize;
+    for (segment_index, segment) in segments.iter().enumerate() {
+        if segment.end <= segment.start {
+            bail!("segment {segment_index} has an invalid frame range");
+        }
+        if segment.label == blank {
+            continue;
+        }
+        let expected = targets
+            .get(target_index)
+            .copied()
+            .context("alignment path contains more non-blank runs than targets")?;
+        if segment.label != expected {
+            bail!(
+                "alignment run {} has label {}, expected {expected}",
+                segment_index,
+                segment.label
+            );
+        }
+        target_segments.push(segment_index);
+        target_index += 1;
+    }
+    if target_index != targets.len() {
+        bail!(
+            "alignment path contains {target_index} target runs, expected {}",
+            targets.len()
+        );
+    }
+
+    let mut spans = Vec::with_capacity(targets.len());
+    for (index, &segment_index) in target_segments.iter().enumerate() {
+        let segment = &segments[segment_index];
+        let mut start = segment.start;
+        let mut end = segment.end;
+        let mut weighted_score = segment.score * (segment.end - segment.start) as f32;
+        let mut score_frames = segment.end - segment.start;
+        if segment_index > 0 && segments[segment_index - 1].label == blank {
+            let previous = &segments[segment_index - 1];
+            let padded_start = if index == 0 {
+                previous.start
+            } else {
+                (previous.start + previous.end) / 2
+            };
+            if padded_start < start {
+                weighted_score += previous.score * (start - padded_start) as f32;
+                score_frames += start - padded_start;
+                start = padded_start;
+            }
+        }
+        if segment_index + 1 < segments.len() && segments[segment_index + 1].label == blank {
+            let next = &segments[segment_index + 1];
+            let padded_end = if index + 1 == targets.len() {
+                next.end
+            } else {
+                (next.start + next.end) / 2
+            };
+            if padded_end > end {
+                weighted_score += next.score * (padded_end - end) as f32;
+                score_frames += padded_end - end;
+                end = padded_end;
+            }
+        }
+        spans.push(AlignmentSpan {
+            start,
+            end,
+            score: weighted_score / score_frames as f32,
+        });
+    }
+    Ok(spans)
+}
+
+pub fn iso_639_3(language: Option<&str>) -> Option<&'static str> {
+    let code = language?.trim().to_ascii_lowercase();
+    match code.as_str() {
+        "af" | "afr" => Some("afr"),
+        "sq" | "sqi" | "alb" => Some("sqi"),
+        "am" | "amh" => Some("amh"),
+        "ar" | "ara" | "arb" => Some("ara"),
+        "hy" | "hye" | "arm" => Some("hye"),
+        "as" | "asm" => Some("asm"),
+        "az" | "aze" => Some("aze"),
+        "eu" | "eus" | "baq" => Some("eus"),
+        "ba" | "bak" => Some("bak"),
+        "be" | "bel" => Some("bel"),
+        "bn" | "ben" => Some("ben"),
+        "bs" | "bos" => Some("bos"),
+        "br" | "bre" => Some("bre"),
+        "bg" | "bul" => Some("bul"),
+        "yue" => Some("yue"),
+        "ca" | "cat" => Some("cat"),
+        "zh" | "zho" | "chi" | "cmn" | "zh-cn" | "zh-tw" => Some("zho"),
+        "hr" | "hrv" => Some("hrv"),
+        "cs" | "ces" | "cze" => Some("ces"),
+        "da" | "dan" => Some("dan"),
+        "nl" | "nld" | "dut" => Some("nld"),
+        "en" | "eng" => Some("eng"),
+        "et" | "est" => Some("est"),
+        "fo" | "fao" => Some("fao"),
+        "fi" | "fin" => Some("fin"),
+        "fr" | "fra" | "fre" => Some("fra"),
+        "gl" | "glg" => Some("glg"),
+        "ka" | "kat" | "geo" => Some("kat"),
+        "de" | "deu" | "ger" => Some("deu"),
+        "el" | "ell" | "gre" => Some("ell"),
+        "gu" | "guj" => Some("guj"),
+        "ht" | "hat" => Some("hat"),
+        "ha" | "hau" => Some("hau"),
+        "haw" => Some("haw"),
+        "he" | "heb" => Some("heb"),
+        "hi" | "hin" => Some("hin"),
+        "hu" | "hun" => Some("hun"),
+        "is" | "isl" | "ice" => Some("isl"),
+        "id" | "ind" => Some("ind"),
+        "it" | "ita" => Some("ita"),
+        "ja" | "jpn" => Some("jpn"),
+        "jw" | "jv" | "jav" => Some("jav"),
+        "kn" | "kan" => Some("kan"),
+        "kk" | "kaz" => Some("kaz"),
+        "km" | "khm" => Some("khm"),
+        "ko" | "kor" => Some("kor"),
+        "lo" | "lao" => Some("lao"),
+        "la" | "lat" => Some("lat"),
+        "lv" | "lav" => Some("lav"),
+        "lt" | "lit" => Some("lit"),
+        "ln" | "lin" => Some("lin"),
+        "lb" | "ltz" => Some("ltz"),
+        "mk" | "mkd" | "mac" => Some("mkd"),
+        "mg" | "mlg" => Some("mlg"),
+        "ms" | "msa" | "may" => Some("msa"),
+        "ml" | "mal" => Some("mal"),
+        "mt" | "mlt" => Some("mlt"),
+        "mi" | "mri" | "mao" => Some("mri"),
+        "mr" | "mar" => Some("mar"),
+        "mn" | "mon" => Some("mon"),
+        "my" | "mya" | "bur" => Some("mya"),
+        "ne" | "nep" => Some("nep"),
+        "no" | "nor" => Some("nor"),
+        "nn" | "nno" => Some("nno"),
+        "oc" | "oci" => Some("oci"),
+        "ps" | "pus" => Some("pus"),
+        "fa" | "fas" | "per" => Some("fas"),
+        "pl" | "pol" => Some("pol"),
+        "pt" | "por" => Some("por"),
+        "pa" | "pan" => Some("pan"),
+        "ro" | "ron" | "rum" => Some("ron"),
+        "ru" | "rus" => Some("rus"),
+        "sa" | "san" => Some("san"),
+        "sr" | "srp" => Some("srp"),
+        "sn" | "sna" => Some("sna"),
+        "sd" | "snd" => Some("snd"),
+        "si" | "sin" => Some("sin"),
+        "sk" | "slk" | "slo" => Some("slk"),
+        "sl" | "slv" => Some("slv"),
+        "so" | "som" => Some("som"),
+        "es" | "spa" => Some("spa"),
+        "su" | "sun" => Some("sun"),
+        "sw" | "swa" => Some("swa"),
+        "sv" | "swe" => Some("swe"),
+        "tl" | "fil" | "tgl" => Some("fil"),
+        "tg" | "tgk" => Some("tgk"),
+        "ta" | "tam" => Some("tam"),
+        "tt" | "tat" => Some("tat"),
+        "te" | "tel" => Some("tel"),
+        "th" | "tha" => Some("tha"),
+        "bo" | "bod" | "tib" => Some("bod"),
+        "tr" | "tur" => Some("tur"),
+        "tk" | "tuk" => Some("tuk"),
+        "uk" | "ukr" => Some("ukr"),
+        "ur" | "urd" => Some("urd"),
+        "uz" | "uzb" => Some("uzb"),
+        "vi" | "vie" => Some("vie"),
+        "cy" | "cym" | "wel" => Some("cym"),
+        "yi" | "yid" => Some("yid"),
+        "yo" | "yor" => Some("yor"),
+        "auto" | "und" | "" => None,
+        _ => None,
+    }
+}
+
+fn prepare_text_with(
+    uroman: &Uroman,
+    vocabulary: &HashMap<String, usize>,
+    text: &str,
+    language: Option<&str>,
+) -> Result<Vec<AlignmentUnit>> {
+    if text.trim().is_empty() {
+        bail!("transcript is empty or whitespace-only");
+    }
+    let iso = iso_639_3(language);
+    let is_cjk = matches!(iso, Some("jpn" | "zho" | "yue"));
+    let source_units = split_display_units(text, is_cjk);
+    let mut units = Vec::new();
+    for original_text in source_units {
+        let normalized = normalize_text_unit(&original_text);
+        if normalized.is_empty() {
+            continue;
+        }
+        let romanized = uroman
+            .romanize_string::<rom_format::Str>(&normalized, iso)
+            .to_string();
+        let filtered = filter_romanized(&romanized);
+        if filtered.is_empty() {
+            if is_cjk {
+                units.push(AlignmentUnit {
+                    original_text,
+                    normalized_tokens: vec![vocabulary.len()],
+                });
+            }
+            continue;
+        }
+        let mut normalized_tokens = Vec::new();
+        for character in filtered
+            .chars()
+            .filter(|character| !character.is_whitespace())
+        {
+            let token = character.to_string();
+            let id = vocabulary.get(&token).copied().ok_or_else(|| {
+                eyre!("normalized character {character:?} is not in the model vocabulary")
+            })?;
+            normalized_tokens.push(id);
+        }
+        if !normalized_tokens.is_empty() {
+            units.push(AlignmentUnit {
+                original_text,
+                normalized_tokens,
+            });
+        }
+    }
+    if units.is_empty() {
+        bail!("transcript contains no alignable text after normalization");
+    }
+    Ok(units)
+}
+
+fn split_display_units(text: &str, character_units: bool) -> Vec<String> {
+    let mut units = Vec::new();
+    let mut pending_space = String::new();
+    if character_units {
+        for character in text.chars() {
+            if character.is_whitespace() {
+                pending_space.push(character);
+            } else {
+                let mut unit = std::mem::take(&mut pending_space);
+                unit.push(character);
+                units.push(unit);
+            }
+        }
+    } else {
+        let mut current = String::new();
+        for character in text.chars() {
+            if character.is_whitespace() {
+                if !current.is_empty() {
+                    units.push(std::mem::take(&mut current));
+                }
+                pending_space.push(character);
+            } else {
+                if current.is_empty() {
+                    current.push_str(&pending_space);
+                    pending_space.clear();
+                }
+                current.push(character);
+            }
+        }
+        if !current.is_empty() {
+            units.push(current);
+        }
+    }
+    units
+}
+
+fn normalize_text_unit(text: &str) -> String {
+    let text = remove_numeric_parentheticals(text);
+    let mapped: String = text
+        .nfkc()
+        .flat_map(char::to_lowercase)
+        .map(|character| match character {
+            '\u{2018}' | '\u{2019}' | '\u{201b}' | '\u{02bc}' => '\'',
+            '\u{066c}' | '\u{060c}' | '\u{061b}' | '\u{061f}' | '\u{0964}' | '\u{3001}'
+            | '\u{3002}' => ' ',
+            '\u{200b}' | '\u{200c}' | '\u{200d}' | '\u{200e}' | '\u{200f}' | '\u{202a}'
+            | '\u{202c}' | '\u{0640}' => '\0',
+            other => other,
+        })
+        .filter(|character| *character != '\0' && !is_combining_mark(*character))
+        .map(|character| {
+            if is_punctuation(character) {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect();
+    let mut words = Vec::new();
+    for word in mapped.split_whitespace() {
+        if word.chars().all(is_numeric_character) {
+            continue;
+        }
+        words.push(word);
+    }
+    words.join(" ")
+}
+
+fn remove_numeric_parentheticals(text: &str) -> String {
+    let characters: Vec<char> = text.chars().collect();
+    let mut output = String::with_capacity(text.len());
+    let mut index = 0usize;
+    while index < characters.len() {
+        if characters[index] == '(' {
+            if let Some(relative_end) = characters[index + 1..]
+                .iter()
+                .position(|character| *character == ')')
+            {
+                let end = index + relative_end + 1;
+                if characters[index + 1..end]
+                    .iter()
+                    .any(|character| character.is_numeric())
+                {
+                    output.push(' ');
+                    index = end + 1;
+                    continue;
+                }
+            }
+        }
+        output.push(characters[index]);
+        index += 1;
+    }
+    output
+}
+
+fn filter_romanized(text: &str) -> String {
+    let mut output = String::new();
+    let mut previous_space = true;
+    for character in text.chars().flat_map(char::to_lowercase) {
+        if character.is_ascii_lowercase() || character == '\'' {
+            output.push(character);
+            previous_space = false;
+        } else if character.is_whitespace() && !previous_space {
+            output.push(' ');
+            previous_space = true;
+        }
+    }
+    output.trim().to_string()
+}
+
+fn is_numeric_character(character: char) -> bool {
+    character.is_numeric() || matches!(character, '\u{2170}'..='\u{2179}' | '\u{ff10}'..='\u{ff19}')
+}
+
+fn is_punctuation(character: char) -> bool {
+    if character == '\'' {
+        return false;
+    }
+    character.is_ascii_punctuation()
+        || matches!(
+            character,
+            '\u{00a1}' | '\u{00ab}' | '\u{00bb}' | '\u{00bf}'
+                | '\u{055a}'..='\u{055f}' | '\u{0589}' | '\u{2000}'..='\u{206f}'
+                | '\u{2500}' | '\u{3000}'..='\u{303f}' | '\u{fe4f}'
+                | '\u{ff01}'..='\u{ff0f}' | '\u{ff1a}'..='\u{ff20}'
+                | '\u{ff3b}'..='\u{ff40}' | '\u{ff5b}'..='\u{ff65}'
+        )
+}
+
+fn build_targets(
+    units: &[AlignmentUnit],
+    star_id: usize,
+) -> Result<(Vec<usize>, Vec<std::ops::Range<usize>>)> {
+    let target_capacity = units
+        .iter()
+        .try_fold(0usize, |total, unit| {
+            total
+                .checked_add(1)?
+                .checked_add(unit.normalized_tokens.len())
+        })
+        .context("target length overflow")?;
+    let mut targets = Vec::with_capacity(target_capacity);
+    let mut ranges = Vec::with_capacity(units.len());
+    for unit in units {
+        targets.push(star_id);
+        let start = targets.len();
+        targets.extend_from_slice(&unit.normalized_tokens);
+        ranges.push(start..targets.len());
+    }
+    Ok((targets, ranges))
+}
+
+fn read_json(path: &Path) -> Result<Value> {
+    let contents =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    serde_json::from_str(&contents).with_context(|| format!("failed to parse {}", path.display()))
+}
+
+fn json_usize(value: &Value, key: &str) -> Result<usize> {
+    let raw = value
+        .get(key)
+        .and_then(Value::as_u64)
+        .ok_or_else(|| eyre!("configuration is missing unsigned integer {key}"))?;
+    usize::try_from(raw).with_context(|| format!("configuration value {key} does not fit usize"))
+}
+
+fn config_ratio(config: &Value) -> Result<usize> {
+    if let Some(value) = config.get("inputs_to_logits_ratio").and_then(Value::as_u64) {
+        return usize::try_from(value).context("inputs_to_logits_ratio does not fit usize");
+    }
+    let strides = config
+        .get("conv_stride")
+        .and_then(Value::as_array)
+        .context("config.json has neither inputs_to_logits_ratio nor conv_stride")?;
+    strides.iter().try_fold(1usize, |ratio, stride| {
+        let stride = stride
+            .as_u64()
+            .context("conv_stride entries must be unsigned integers")?;
+        ratio
+            .checked_mul(usize::try_from(stride).context("conv_stride does not fit usize")?)
+            .context("convolution stride product overflow")
+    })
+}
+
+fn validate_session(session: &Session, classes: usize) -> Result<()> {
+    let input = session
+        .inputs()
+        .iter()
+        .find(|input| input.name() == "input_values")
+        .context("ONNX model does not have input_values input")?;
+    match input.dtype() {
+        ValueType::Tensor { shape, .. } if shape.len() == 2 => {}
+        other => bail!("input_values must be a rank-2 tensor, got {other:?}"),
+    }
+    let output = session
+        .outputs()
+        .iter()
+        .find(|output| output.name() == "logits" || output.name() == "output_0")
+        .context("ONNX model does not have logits output")?;
+    match output.dtype() {
+        ValueType::Tensor { shape, .. } if shape.len() == 3 => {
+            let output_classes = shape[2];
+            if output_classes >= 0 && output_classes != classes as i64 {
+                bail!(
+                    "model declares {output_classes} output classes, but vocabulary has {classes}"
+                );
+            }
+        }
+        other => bail!("logits must be a rank-3 tensor, got {other:?}"),
+    }
+    Ok(())
+}
+
+fn check_cancelled(cancellation: Cancellation<'_>) -> Result<()> {
+    if cancellation.is_some_and(|is_cancelled| is_cancelled()) {
+        bail!("Alignment cancelled");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    fn vocabulary() -> HashMap<String, usize> {
+        let mut vocabulary = HashMap::new();
+        vocabulary.insert("<blank>".to_string(), 0);
+        for (index, character) in ('a'..='z').enumerate() {
+            vocabulary.insert(character.to_string(), index + 1);
+        }
+        vocabulary.insert("'".to_string(), 27);
+        vocabulary.insert("|".to_string(), 28);
+        vocabulary.insert("<unk>".to_string(), 29);
+        vocabulary.insert("<pad>".to_string(), 30);
+        vocabulary
+    }
+
+    #[test]
+    fn sample_normalization_matches_golden_values() {
+        let result = normalize_samples(&[-32768, 0, 32767]);
+        let expected = [-1.2247635, 0.00001246, 1.224751];
+        for (actual, expected) in result.iter().zip(expected) {
+            assert!((actual - expected).abs() < 2e-5, "{actual} != {expected}");
+        }
+        assert_eq!(normalize_samples(&[0, 0, 0]), vec![0.0; 3]);
+        assert!(normalize_samples(&[]).is_empty());
+    }
+
+    #[test]
+    fn log_softmax_and_star_column_match_golden_matrix() {
+        let logits = array![[1.0, 2.0, 3.0], [1000.0, 1000.0, 999.0]];
+        let result = augment_log_probs(logits.view(), 3).expect("augmentation should succeed");
+        let expected = array![
+            [-2.407606, -1.407606, -0.407606, 0.0],
+            [-0.861995, -0.861995, -1.861995, 0.0]
+        ];
+        assert_eq!(result.dim(), (2, 4));
+        for (actual, expected) in result.iter().zip(expected.iter()) {
+            assert!((actual - expected).abs() < 1e-5);
+            assert!(actual.is_finite());
+        }
+        assert!(log_softmax(array![[f32::NAN]].view()).is_err());
+    }
+
+    #[test]
+    fn forced_alignment_matches_golden_normal_path() {
+        let emissions = array![
+            [-0.1, -3.0, -4.0],
+            [-2.0, -0.1, -4.0],
+            [-0.2, -2.0, -3.0],
+            [-2.0, -3.0, -0.1],
+            [-0.1, -3.0, -2.0]
+        ];
+        let result =
+            forced_align(emissions.view(), &[1, 2], 0, None).expect("alignment should succeed");
+        assert_eq!(result.labels, vec![0, 1, 0, 2, 0]);
+        assert_eq!(result.scores, vec![-0.1, -0.1, -0.2, -0.1, -0.1]);
+    }
+
+    #[test]
+    fn forced_alignment_handles_repeats_blank_heavy_and_star() {
+        let repeated = array![[-2.0, -0.1], [-0.1, -3.0], [-3.0, -0.1]];
+        let result = forced_align(repeated.view(), &[1, 1], 0, None).expect("repeat should align");
+        assert_eq!(result.labels, vec![1, 0, 1]);
+
+        let blank_heavy = array![
+            [-0.1, -4.0, -4.0],
+            [-0.1, -3.0, -4.0],
+            [-2.0, -0.1, -4.0],
+            [-0.1, -3.0, -4.0],
+            [-0.1, -4.0, -3.0],
+            [-2.0, -4.0, -0.1],
+            [-0.1, -4.0, -3.0]
+        ];
+        let result = forced_align(blank_heavy.view(), &[1, 2], 0, None)
+            .expect("blank-heavy path should align");
+        assert_eq!(result.labels, vec![0, 0, 1, 0, 0, 2, 0]);
+
+        let star = array![[-2.0, 0.0], [-2.0, 0.0], [-0.1, 0.0]];
+        let result = forced_align(star.view(), &[1], 0, None).expect("star target should align");
+        assert_eq!(result.labels, vec![1, 1, 1]);
+    }
+
+    #[test]
+    fn forced_alignment_rejects_invalid_and_cancelled_inputs() {
+        let emissions = Array2::zeros((2, 3));
+        assert!(forced_align(emissions.view(), &[], 0, None).is_err());
+        assert!(forced_align(emissions.view(), &[0], 0, None).is_err());
+        assert!(forced_align(emissions.view(), &[3], 0, None).is_err());
+        assert!(forced_align(emissions.view(), &[1, 1], 0, None).is_err());
+        assert!(forced_align(emissions.view(), &[1], 3, None).is_err());
+        let cancelled = AtomicBool::new(true);
+        let callback = || cancelled.load(Ordering::Relaxed);
+        assert!(forced_align(emissions.view(), &[1], 0, Some(&callback)).is_err());
+        assert!(Array2::<f32>::from_shape_vec((usize::MAX, 2), Vec::new()).is_err());
+    }
+
+    #[test]
+    fn merge_and_midpoint_spans_match_golden_output() {
+        let path = AlignmentPath {
+            labels: vec![0, 0, 1, 1, 0, 0, 0, 2, 0, 0],
+            scores: vec![-0.2, -0.2, -0.1, -0.3, -0.4, -0.4, -0.4, -0.2, -0.5, -0.5],
+        };
+        let segments = merge_repeats(&path).expect("merge should succeed");
+        assert_eq!(
+            segments
+                .iter()
+                .map(|segment| (segment.label, segment.start, segment.end))
+                .collect::<Vec<_>>(),
+            vec![(0, 0, 2), (1, 2, 4), (0, 4, 7), (2, 7, 8), (0, 8, 10)]
+        );
+        let spans = get_spans(&[1, 2], &segments, 0).expect("span extraction should succeed");
+        assert_eq!((spans[0].start, spans[0].end), (0, 5));
+        assert_eq!((spans[1].start, spans[1].end), (5, 10));
+        assert!((spans[0].score - -0.24).abs() < 1e-6);
+        assert!((spans[1].score - -0.4).abs() < 1e-6);
+    }
+
+    #[test]
+    fn normalization_covers_latin_apostrophes_digits_and_punctuation() {
+        assert_eq!(normalize_text_unit(" HéLLo,  WORLD! "), "héllo world");
+        assert_eq!(normalize_text_unit("l’amour"), "l'amour");
+        assert_eq!(normalize_text_unit("123"), "");
+        assert_eq!(normalize_text_unit("version2"), "version2");
+        assert_eq!(normalize_text_unit("(Sam 23:17)"), "");
+    }
+
+    #[test]
+    fn language_mapping_covers_selectable_aliases() {
+        assert_eq!(iso_639_3(Some("en")), Some("eng"));
+        assert_eq!(iso_639_3(Some("zh-CN")), Some("zho"));
+        assert_eq!(iso_639_3(Some("chi")), Some("zho"));
+        assert_eq!(iso_639_3(Some("jw")), Some("jav"));
+        assert_eq!(iso_639_3(Some("auto")), None);
+        assert_eq!(iso_639_3(Some("unknown")), None);
+    }
+
+    #[test]
+    fn text_preparation_romanizes_and_preserves_display_units() {
+        let uroman = Uroman::new();
+        let vocabulary = vocabulary();
+        let latin = prepare_text_with(&uroman, &vocabulary, "Hello, world!", Some("en"))
+            .expect("Latin text should prepare");
+        assert_eq!(
+            latin
+                .iter()
+                .map(|unit| unit.original_text.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Hello,", " world!"]
+        );
+        assert_eq!(latin[0].normalized_tokens, vec![8, 5, 12, 12, 15]);
+
+        let cyrillic = prepare_text_with(&uroman, &vocabulary, "Привет", Some("ru"))
+            .expect("Cyrillic text should romanize");
+        assert_eq!(cyrillic[0].original_text, "Привет");
+        assert!(cyrillic[0].normalized_tokens.len() >= 6);
+
+        let arabic = prepare_text_with(&uroman, &vocabulary, "مرحبا", Some("ar"))
+            .expect("Arabic text should romanize");
+        assert_eq!(arabic[0].original_text, "مرحبا");
+        assert!(!arabic[0].normalized_tokens.is_empty());
+
+        let japanese = prepare_text_with(&uroman, &vocabulary, "日本", Some("ja"))
+            .expect("Japanese text should prepare by character");
+        assert_eq!(japanese.len(), 2);
+        assert_eq!(japanese[0].original_text, "日");
+        assert_eq!(japanese[1].original_text, "本");
+
+        let chinese = prepare_text_with(&uroman, &vocabulary, "中文", Some("zh"))
+            .expect("Chinese text should prepare by character");
+        assert_eq!(chinese.len(), 2);
+        assert_eq!(chinese[0].original_text, "中");
+    }
+
+    #[test]
+    fn romanization_expansion_stays_attached_to_original_unit() {
+        let units = prepare_text_with(&Uroman::new(), &vocabulary(), "ユーロマン", Some("ja"))
+            .expect("Japanese should romanize");
+        assert_eq!(units.len(), 5);
+        assert_eq!(
+            units
+                .iter()
+                .map(|unit| unit.original_text.clone())
+                .collect::<String>(),
+            "ユーロマン"
+        );
+        assert!(units.iter().any(|unit| unit.normalized_tokens.len() > 1));
+    }
+
+    #[test]
+    fn text_preparation_rejects_unalignable_text_without_panicking() {
+        let uroman = Uroman::new();
+        let vocabulary = vocabulary();
+        assert!(prepare_text_with(&uroman, &vocabulary, "", None).is_err());
+        assert!(prepare_text_with(&uroman, &vocabulary, "   ", None).is_err());
+        assert!(prepare_text_with(&uroman, &vocabulary, "!!!", None).is_err());
+        assert!(prepare_text_with(&uroman, &vocabulary, "12345", None).is_err());
+        assert!(prepare_text_with(&uroman, &vocabulary, "✨", None).is_err());
+    }
+
+    #[test]
+    fn timestamps_use_fixed_twenty_millisecond_frames() {
+        assert_eq!(FRAME_SECONDS, 0.02);
+        let frame = 123_456usize;
+        assert!((frame as f64 * FRAME_SECONDS - 2469.12).abs() < 1e-9);
+    }
+}

--- a/AutoSubs-App/src-tauri/crates/transcription-engine/src/align.rs
+++ b/AutoSubs-App/src-tauri/crates/transcription-engine/src/align.rs
@@ -780,28 +780,28 @@ fn prepare_text_with(
     let is_cjk = matches!(iso, Some("jpn" | "zho" | "yue"));
     let source_units = split_display_units(text, is_cjk);
     let mut units = Vec::new();
+    let star_id = vocabulary.len();
     for original_text in source_units {
         let normalized = normalize_text_unit(&original_text);
         if normalized.is_empty() {
+            // Symbols, numeric parentheticals, and other text that normalizes
+            // away still deserve a star token so the original word survives.
+            units.push(AlignmentUnit {
+                original_text,
+                normalized_tokens: vec![star_id],
+            });
             continue;
         }
         let romanized = uroman
             .romanize_string::<rom_format::Str>(&normalized, iso)
             .to_string();
         let filtered = filter_romanized(&romanized);
-        if filtered.is_empty() {
-            if is_cjk {
-                units.push(AlignmentUnit {
-                    original_text,
-                    normalized_tokens: vec![vocabulary.len()],
-                });
-            } else {
-                tracing::warn!(
-                    original_text = %original_text,
-                    language = ?language,
-                    "alignment unit dropped: uroman produced no alignable ASCII text"
-                );
-            }
+        if filtered.is_empty() || filtered.chars().all(|character| character.is_ascii_digit()) {
+            // Pure numbers or unromanizable text fall back to a single star token.
+            units.push(AlignmentUnit {
+                original_text,
+                normalized_tokens: vec![star_id],
+            });
             continue;
         }
         let mut normalized_tokens = Vec::new();
@@ -809,6 +809,10 @@ fn prepare_text_with(
             .chars()
             .filter(|character| !character.is_whitespace())
         {
+            if character.is_ascii_digit() {
+                normalized_tokens.push(star_id);
+                continue;
+            }
             let token = character.to_string();
             let id = vocabulary.get(&token).copied().ok_or_else(|| {
                 eyre!("normalized character {character:?} is not in the model vocabulary")
@@ -888,14 +892,7 @@ fn normalize_text_unit(text: &str) -> String {
             }
         })
         .collect();
-    let mut words = Vec::new();
-    for word in mapped.split_whitespace() {
-        if word.chars().all(is_numeric_character) {
-            continue;
-        }
-        words.push(word);
-    }
-    words.join(" ")
+    mapped.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 fn remove_numeric_parentheticals(text: &str) -> String {
@@ -929,7 +926,7 @@ fn filter_romanized(text: &str) -> String {
     let mut output = String::new();
     let mut previous_space = true;
     for character in text.chars().flat_map(char::to_lowercase) {
-        if character.is_ascii_lowercase() || character == '\'' {
+        if character.is_ascii_lowercase() || character == '\'' || character.is_ascii_digit() {
             output.push(character);
             previous_space = false;
         } else if character.is_whitespace() && !previous_space {
@@ -938,10 +935,6 @@ fn filter_romanized(text: &str) -> String {
         }
     }
     output.trim().to_string()
-}
-
-fn is_numeric_character(character: char) -> bool {
-    character.is_numeric() || matches!(character, '\u{2170}'..='\u{2179}' | '\u{ff10}'..='\u{ff19}')
 }
 
 fn is_punctuation(character: char) -> bool {
@@ -1174,7 +1167,7 @@ mod tests {
     fn normalization_covers_latin_apostrophes_digits_and_punctuation() {
         assert_eq!(normalize_text_unit(" HéLLo,  WORLD! "), "héllo world");
         assert_eq!(normalize_text_unit("l’amour"), "l'amour");
-        assert_eq!(normalize_text_unit("123"), "");
+        assert_eq!(normalize_text_unit("123"), "123");
         assert_eq!(normalize_text_unit("version2"), "version2");
         assert_eq!(normalize_text_unit("(Sam 23:17)"), "");
     }
@@ -1242,14 +1235,34 @@ mod tests {
     }
 
     #[test]
-    fn text_preparation_rejects_unalignable_text_without_panicking() {
+    fn text_preparation_uses_star_fallback_for_unalignable_units() {
         let uroman = Uroman::new();
         let vocabulary = vocabulary();
+        let star_id = vocabulary.len();
+
         assert!(prepare_text_with(&uroman, &vocabulary, "", None).is_err());
         assert!(prepare_text_with(&uroman, &vocabulary, "   ", None).is_err());
-        assert!(prepare_text_with(&uroman, &vocabulary, "!!!", None).is_err());
-        assert!(prepare_text_with(&uroman, &vocabulary, "12345", None).is_err());
-        assert!(prepare_text_with(&uroman, &vocabulary, "✨", None).is_err());
+
+        for text in ["!!!", "12345", "✨"] {
+            let units = prepare_text_with(&uroman, &vocabulary, text, None)
+                .unwrap_or_else(|error| panic!("{text:?} should prepare with a star token: {error}"));
+            assert_eq!(units.len(), 1, "{text:?} should produce exactly one unit");
+            assert_eq!(units[0].original_text, text);
+            assert_eq!(units[0].normalized_tokens, vec![star_id]);
+        }
+    }
+
+    #[test]
+    fn text_preparation_preserves_digits_in_mixed_words() {
+        let uroman = Uroman::new();
+        let vocabulary = vocabulary();
+        let star_id = vocabulary.len();
+
+        let units = prepare_text_with(&uroman, &vocabulary, "section2", None)
+            .expect("mixed alphanumeric word should prepare");
+        assert_eq!(units.len(), 1);
+        assert_eq!(units[0].original_text, "section2");
+        assert_eq!(units[0].normalized_tokens.last().copied(), Some(star_id));
     }
 
     #[test]

--- a/AutoSubs-App/src-tauri/crates/transcription-engine/src/align.rs
+++ b/AutoSubs-App/src-tauri/crates/transcription-engine/src/align.rs
@@ -11,6 +11,15 @@ use std::path::Path;
 use unicode_normalization::{UnicodeNormalization, char::is_combining_mark};
 use uroman::{Uroman, rom_format};
 
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+
+/// Cache for ISO-639-3 pass-through codes that are not in the hard-coded alias
+/// table. Each distinct code is leaked once so the returned `&'static str` stays
+/// valid for the life of the process.
+static ISO_639_3_CACHE: Lazy<Mutex<HashMap<String, &'static str>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
 const SAMPLE_RATE: usize = 16_000;
 const INPUTS_TO_LOGITS_RATIO: usize = 320;
 const WINDOW_SAMPLES: usize = 30 * SAMPLE_RATE;
@@ -748,6 +757,12 @@ pub fn iso_639_3(language: Option<&str>) -> Option<&'static str> {
         "yi" | "yid" => Some("yid"),
         "yo" | "yor" => Some("yor"),
         "auto" | "und" | "" => None,
+        _ if code.len() == 3 && code.chars().all(|c| c.is_ascii_alphabetic()) => {
+            let mut cache = ISO_639_3_CACHE.lock().unwrap();
+            Some(*cache.entry(code.clone()).or_insert_with(|| {
+                Box::leak(code.into_boxed_str())
+            }))
+        }
         _ => None,
     }
 }
@@ -780,6 +795,12 @@ fn prepare_text_with(
                     original_text,
                     normalized_tokens: vec![vocabulary.len()],
                 });
+            } else {
+                tracing::warn!(
+                    original_text = %original_text,
+                    language = ?language,
+                    "alignment unit dropped: uroman produced no alignable ASCII text"
+                );
             }
             continue;
         }
@@ -802,7 +823,9 @@ fn prepare_text_with(
         }
     }
     if units.is_empty() {
-        bail!("transcript contains no alignable text after normalization");
+        bail!(
+            "transcript contains no alignable text after normalization (language={language:?}); the language or script may not be supported by the romanizer"
+        );
     }
     Ok(units)
 }

--- a/AutoSubs-App/src-tauri/crates/transcription-engine/src/engine.rs
+++ b/AutoSubs-App/src-tauri/crates/transcription-engine/src/engine.rs
@@ -386,13 +386,18 @@ impl Engine {
         let native_target =
             resolve_native_target(engine_kind, &from_lang, translate_to.as_deref(), use_native);
 
+        let mut engine_cfg = self.cfg.clone();
+        if enable_forced_alignment {
+            engine_cfg.enable_dtw = Some(false);
+        }
+
         let (mut segments, detected_lang) = crate::engines::run_engine(
             engine_kind,
             _model_path.as_path(),
             speech_segments,
             &options,
             native_target.as_deref(),
-            &self.cfg,
+            &engine_cfg,
             cb.progress,
             cb.new_segment_callback,
             engine_cancellation,
@@ -402,7 +407,12 @@ impl Engine {
         // Choose effective language: detected if present, otherwise the user-provided from_lang
         let effective_lang: &str = detected_lang.as_deref().unwrap_or(&from_lang);
 
-        if enable_forced_alignment && translate_to.is_none() {
+        let has_native_word_timestamps = matches!(
+            engine_kind,
+            ModelEngine::Parakeet | ModelEngine::SenseVoice
+        );
+
+        if enable_forced_alignment && translate_to.is_none() && !has_native_word_timestamps {
             if alignment_cancellation
                 .as_ref()
                 .is_some_and(|cancelled| cancelled())
@@ -440,7 +450,14 @@ impl Engine {
                 alignment_cancellation.as_deref(),
             )?;
         } else if enable_forced_alignment {
-            tracing::info!("forced alignment skipped because translation is enabled");
+            if has_native_word_timestamps {
+                tracing::info!(
+                    "forced alignment skipped: {} provides native word-level timestamps",
+                    options.model
+                );
+            } else {
+                tracing::info!("forced alignment skipped because translation is enabled");
+            }
         }
 
         // `use_native_translation` requests the model's built-in translation.

--- a/AutoSubs-App/src-tauri/crates/transcription-engine/src/engine.rs
+++ b/AutoSubs-App/src-tauri/crates/transcription-engine/src/engine.rs
@@ -1,7 +1,8 @@
-use std::path::PathBuf;
+use crate::formatting::{PostProcessConfig, TextCase, TextDensity, process_segments};
+use crate::types::{LabeledProgressFn, NewSegmentFn, Segment, SpeechSegment};
 use eyre::eyre;
-use crate::types::{SpeechSegment, LabeledProgressFn, NewSegmentFn, Segment};
-use crate::formatting::{process_segments, PostProcessConfig, TextCase, TextDensity};
+use std::path::PathBuf;
+use std::sync::Arc;
 
 /// Frontend-requested content formatting applied after structural line-wrapping.
 #[derive(Clone, Debug, Default)]
@@ -16,14 +17,15 @@ use crate::manifest::{self, Engine as ModelEngine};
 
 #[derive(Clone, Debug)]
 pub struct EngineConfig {
-    pub cache_dir: PathBuf, // Cache directory for downloaded models
+    pub cache_dir: PathBuf,              // Cache directory for downloaded models
     pub enable_dtw: Option<bool>, // Enable DTW for better word timestamps - this will disable flash attention
     pub enable_flash_attn: Option<bool>, // Enable flash attention for faster inference (works best for larger models)
-    pub use_gpu: Option<bool>, // Enable GPU acceleration
-    pub gpu_device: Option<i32>, // GPU device id, default 0
-    pub vad_model_path: Option<String>, // Path to Voice Activity Detection (VAD) model
+    pub use_gpu: Option<bool>,           // Enable GPU acceleration
+    pub gpu_device: Option<i32>,         // GPU device id, default 0
+    pub vad_model_path: Option<String>,  // Path to Voice Activity Detection (VAD) model
     pub diarize_segment_model_path: Option<String>, // Optional path to diarization segmentation model; if None, it will be downloaded
     pub diarize_embedding_model_path: Option<String>, // Optional path to diarization embedding model; if None, it will be downloaded
+    pub aligner_model_dir: Option<String>,
 }
 
 impl Default for EngineConfig {
@@ -37,6 +39,7 @@ impl Default for EngineConfig {
             vad_model_path: None,
             diarize_segment_model_path: None,
             diarize_embedding_model_path: None,
+            aligner_model_dir: None,
         }
     }
 }
@@ -58,12 +61,19 @@ async fn prepare_speech_segments(
     is_cancelled: Option<&(dyn Fn() -> bool + Send + Sync + 'static)>,
 ) -> eyre::Result<Vec<SpeechSegment>> {
     let speech_segments = if let Some(true) = options.enable_diarize {
-        let (seg_path, emb_path) = match (&cfg.diarize_segment_model_path, &cfg.diarize_embedding_model_path) {
+        let (seg_path, emb_path) = match (
+            &cfg.diarize_segment_model_path,
+            &cfg.diarize_embedding_model_path,
+        ) {
             (Some(seg), Some(emb)) => (PathBuf::from(seg), PathBuf::from(emb)),
             _ => models.ensure_diarize_models(progress, is_cancelled).await?,
         };
 
-        let threshold = options.advanced.as_ref().and_then(|a| a.diarize_threshold).unwrap_or(0.5);
+        let threshold = options
+            .advanced
+            .as_ref()
+            .and_then(|a| a.diarize_threshold)
+            .unwrap_or(0.5);
         let diarize_options = diarize::DiarizeOptions {
             segment_model_path: seg_path,
             embedding_model_path: emb_path,
@@ -79,7 +89,8 @@ async fn prepare_speech_segments(
                 callback(pct, crate::ProgressType::Diarize, "progressSteps.diarize");
             }
         };
-        let diarize_progress_callback = progress.map(|_| &diarize_progress as &diarize::ProgressFn<'_>);
+        let diarize_progress_callback =
+            progress.map(|_| &diarize_progress as &diarize::ProgressFn<'_>);
 
         diarize::diarize(
             audio_samples,
@@ -145,11 +156,96 @@ fn resolve_native_target(
     }
     match engine_kind {
         ModelEngine::Whisper if target == "en" => Some(target.to_string()),
-        ModelEngine::Canary if crate::engines::canary::canary_supports_translation(from_lang, target) => {
+        ModelEngine::Canary
+            if crate::engines::canary::canary_supports_translation(from_lang, target) =>
+        {
             Some(target.to_string())
         }
         _ => None,
     }
+}
+
+fn align_segments(
+    aligner_dir: &std::path::Path,
+    audio_samples: &[i16],
+    segments: &mut [Segment],
+    language: Option<&str>,
+    user_offset: f64,
+    progress: Option<&LabeledProgressFn>,
+    is_cancelled: Option<&(dyn Fn() -> bool + Send + Sync)>,
+) -> eyre::Result<()> {
+    let mut aligner = crate::align::Aligner::load(aligner_dir)?;
+    let audio_duration = audio_samples.len() as f64 / 16_000.0;
+    let eligible = segments
+        .iter()
+        .filter(|segment| !segment.text.trim().is_empty())
+        .count();
+    let mut completed = 0usize;
+    if let Some(callback) = progress {
+        callback(
+            if eligible == 0 { 100 } else { 0 },
+            crate::ProgressType::Align,
+            "progressSteps.align",
+        );
+    }
+
+    for segment in segments
+        .iter_mut()
+        .filter(|segment| !segment.text.trim().is_empty())
+    {
+        if is_cancelled.is_some_and(|cancelled| cancelled()) {
+            eyre::bail!("Transcription cancelled");
+        }
+        let audio_start = (segment.start - user_offset - 0.25).clamp(0.0, audio_duration);
+        let audio_end = (segment.end - user_offset + 0.25).clamp(audio_start, audio_duration);
+        let sample_start = (audio_start * 16_000.0).floor() as usize;
+        let sample_end = ((audio_end * 16_000.0).ceil() as usize).min(audio_samples.len());
+        let result = aligner.align_words(
+            &audio_samples[sample_start..sample_end],
+            &segment.text,
+            language,
+            is_cancelled,
+        );
+        match result {
+            Ok(mut words) if !words.is_empty() => {
+                let shift = audio_start + user_offset;
+                let mut previous_end = segment.start;
+                for word in &mut words {
+                    word.start = (word.start + shift).clamp(segment.start, segment.end);
+                    word.end = (word.end + shift).clamp(word.start, segment.end);
+                    word.start = word.start.max(previous_end).min(word.end);
+                    previous_end = word.end;
+                }
+                segment.words = Some(words);
+            }
+            Ok(_) => tracing::warn!(
+                segment_start = segment.start,
+                segment_end = segment.end,
+                "forced alignment produced no words; retaining existing timestamps"
+            ),
+            Err(error) => {
+                if is_cancelled.is_some_and(|cancelled| cancelled()) {
+                    eyre::bail!("Transcription cancelled");
+                }
+                tracing::warn!(
+                    segment_start = segment.start,
+                    segment_end = segment.end,
+                    error = %error,
+                    "forced alignment failed for segment; retaining existing timestamps"
+                );
+            }
+        }
+        completed += 1;
+        if let Some(callback) = progress {
+            let percent = if eligible == 0 {
+                100
+            } else {
+                (completed * 100 / eligible) as i32
+            };
+            callback(percent, crate::ProgressType::Align, "progressSteps.align");
+        }
+    }
+    Ok(())
 }
 
 fn build_post_process_config(
@@ -223,7 +319,9 @@ impl Engine {
         // Route to the appropriate engine based on the manifest. Models not in
         // the manifest fall back to Whisper (legacy behavior).
         let model_entry = manifest::get(&options.model);
-        let engine_kind = model_entry.map(|e| e.engine).unwrap_or(ModelEngine::Whisper);
+        let engine_kind = model_entry
+            .map(|e| e.engine)
+            .unwrap_or(ModelEngine::Whisper);
         // Ensure/download the appropriate model.
         let _model_path = match model_entry {
             Some(entry) => {
@@ -264,7 +362,11 @@ impl Engine {
         );
 
         if let Some(progress_callback) = cb.progress {
-            progress_callback(0, crate::ProgressType::Transcribe, "workspace.empty.loadingModel");
+            progress_callback(
+                0,
+                crate::ProgressType::Transcribe,
+                "workspace.empty.loadingModel",
+            );
         }
 
         let transcribe_start = std::time::Instant::now();
@@ -273,13 +375,16 @@ impl Engine {
         let translate_to = options.translate_target.clone();
         let from_lang = options.lang.clone().unwrap_or_else(|| "auto".to_string());
         let use_native = options.use_native_translation.unwrap_or(false);
+        let enable_forced_alignment = options.enable_forced_alignment.unwrap_or(false);
+        let user_offset = options.offset.unwrap_or(0.0);
+        let alignment_cancellation: Option<Arc<dyn Fn() -> bool + Send + Sync>> =
+            cb.is_cancelled.map(Arc::from);
+        let engine_cancellation = alignment_cancellation
+            .clone()
+            .map(|cancelled| Box::new(move || cancelled()) as Box<dyn Fn() -> bool + Send + Sync>);
 
-        let native_target = resolve_native_target(
-            engine_kind,
-            &from_lang,
-            translate_to.as_deref(),
-            use_native,
-        );
+        let native_target =
+            resolve_native_target(engine_kind, &from_lang, translate_to.as_deref(), use_native);
 
         let (mut segments, detected_lang) = crate::engines::run_engine(
             engine_kind,
@@ -290,12 +395,53 @@ impl Engine {
             &self.cfg,
             cb.progress,
             cb.new_segment_callback,
-            cb.is_cancelled,
+            engine_cancellation,
         )
         .await?;
 
         // Choose effective language: detected if present, otherwise the user-provided from_lang
         let effective_lang: &str = detected_lang.as_deref().unwrap_or(&from_lang);
+
+        if enable_forced_alignment && translate_to.is_none() {
+            if alignment_cancellation
+                .as_ref()
+                .is_some_and(|cancelled| cancelled())
+            {
+                eyre::bail!("Transcription cancelled");
+            }
+            let aligner_dir = match &self.cfg.aligner_model_dir {
+                Some(path) => {
+                    let path = PathBuf::from(path);
+                    for required in [
+                        "onnx/model_int8.onnx",
+                        "vocab.json",
+                        "config.json",
+                        "preprocessor_config.json",
+                    ] {
+                        if !path.join(required).is_file() {
+                            eyre::bail!("Aligner model directory is missing {required}");
+                        }
+                    }
+                    path
+                }
+                None => {
+                    self.models
+                        .ensure_aligner_model(cb.progress, alignment_cancellation.as_deref())
+                        .await?
+                }
+            };
+            align_segments(
+                &aligner_dir,
+                &original_samples,
+                &mut segments,
+                Some(effective_lang),
+                user_offset,
+                cb.progress,
+                alignment_cancellation.as_deref(),
+            )?;
+        } else if enable_forced_alignment {
+            tracing::info!("forced alignment skipped because translation is enabled");
+        }
 
         // `use_native_translation` requests the model's built-in translation.
         // The routing above determined `native_target` — when set, the engine
@@ -311,9 +457,14 @@ impl Engine {
                 // target — translating would be a wasteful no-op and could
                 // even corrupt the text via a round-trip through the API.
                 if effective_lang != to_lang {
-                    crate::translate::translate_segments(segments.as_mut_slice(), effective_lang, to_lang, cb.progress)
-                        .await
-                        .map_err(|e| eyre!("{}", e))?;
+                    crate::translate::translate_segments(
+                        segments.as_mut_slice(),
+                        effective_lang,
+                        to_lang,
+                        cb.progress,
+                    )
+                    .await
+                    .map_err(|e| eyre!("{}", e))?;
                 }
             }
         }

--- a/AutoSubs-App/src-tauri/crates/transcription-engine/src/lib.rs
+++ b/AutoSubs-App/src-tauri/crates/transcription-engine/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod align;
 pub mod audio;
 pub mod engine;
 pub mod engines;

--- a/AutoSubs-App/src-tauri/crates/transcription-engine/src/manifest.rs
+++ b/AutoSubs-App/src-tauri/crates/transcription-engine/src/manifest.rs
@@ -40,6 +40,7 @@ pub struct Manifest {
     pub vad: VadModel,
     /// Speaker diarization model (user-downloadable, has a UI card).
     pub diarize: DiarizeModel,
+    pub aligner: AlignerModel,
 }
 
 /// Silero VAD model, fetched on demand during transcription.
@@ -62,6 +63,24 @@ pub struct DiarizeModel {
     pub files: Vec<String>,
     #[serde(default)]
     pub ui: Option<Ui>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AlignerModel {
+    pub id: String,
+    pub repo: String,
+    pub files: Vec<FileSpec>,
+    pub license: ModelLicense,
+    pub ui: Ui,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ModelLicense {
+    pub spdx: String,
+    pub url: String,
+    pub attribution: String,
+    #[serde(rename = "commercialUse")]
+    pub commercial_use: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -189,8 +208,7 @@ impl FileSpec {
             FileSpec::Plain(_) => false,
             FileSpec::Detailed(f) => {
                 let basename = f.path.rsplit('/').next().unwrap_or(&f.path);
-                f.dest.as_deref().map(|d| d != basename).unwrap_or(false)
-                    || f.path.contains('/')
+                f.dest.as_deref().map(|d| d != basename).unwrap_or(false) || f.path.contains('/')
             }
         }
     }
@@ -241,6 +259,10 @@ pub fn vad() -> &'static VadModel {
 /// The speaker-diarization model.
 pub fn diarize() -> &'static DiarizeModel {
     &MANIFEST.diarize
+}
+
+pub fn aligner() -> &'static AlignerModel {
+    &MANIFEST.aligner
 }
 
 #[cfg(test)]
@@ -298,6 +320,47 @@ mod tests {
         assert!(d.repo.contains('/'), "diarize repo must be owner/name");
         assert!(!d.id.is_empty(), "diarize id must be set");
         assert!(!d.files.is_empty(), "diarize needs >=1 file");
+    }
+
+    #[test]
+    fn aligner_is_wellformed() {
+        let a = aligner();
+        assert!(!a.id.is_empty(), "aligner id must be set");
+        assert_eq!(
+            a.repo.split('/').count(),
+            2,
+            "aligner repo must be owner/name"
+        );
+        assert_eq!(
+            a.files
+                .iter()
+                .filter(|f| f.path().ends_with(".onnx"))
+                .count(),
+            1,
+            "aligner needs exactly one ONNX artifact"
+        );
+        for required in ["vocab.json", "config.json", "preprocessor_config.json"] {
+            assert!(
+                a.files.iter().any(|f| f.path() == required),
+                "aligner is missing {required}"
+            );
+        }
+        assert_eq!(a.license.spdx, "CC-BY-NC-4.0");
+        assert!(!a.license.commercial_use);
+        assert!(a.license.url.starts_with("https://"));
+        assert!(!a.license.attribution.is_empty());
+        assert_eq!(a.ui.size, "317MB");
+        assert!(!a.ui.ram.is_empty());
+        assert!(!a.ui.image.is_empty());
+        assert!(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../../../public")
+                .join(&a.ui.image)
+                .is_file(),
+            "aligner image must exist in public/"
+        );
+        assert!((1..=4).contains(&a.ui.accuracy));
+        assert!((1..=4).contains(&a.ui.weight));
     }
 
     #[test]

--- a/AutoSubs-App/src-tauri/crates/transcription-engine/src/model_manager.rs
+++ b/AutoSubs-App/src-tauri/crates/transcription-engine/src/model_manager.rs
@@ -773,6 +773,16 @@ impl ModelManager {
             }
         }
 
+        let aligner = manifest::aligner();
+        let aligner_files: Vec<&str> = aligner.files.iter().map(FileSpec::path).collect();
+        // Same validation as diarize: partial/corrupt aligner files must not be reported
+        // as cached, otherwise the UI keeps prompting to download a model that exists.
+        if let Ok(Some(snapshot_dir)) = self.find_cached_snapshot_with_files(&aligner.repo, &aligner_files) {
+            if aligner_files.iter().all(|f| validate_model_file(&snapshot_dir.join(f)).is_ok()) {
+                models.insert(aligner.id.clone());
+            }
+        }
+
         let mut result: Vec<String> = models.into_iter().collect();
         result.sort(); // Sort for consistent ordering
         Ok(result)

--- a/AutoSubs-App/src-tauri/crates/transcription-engine/src/model_manager.rs
+++ b/AutoSubs-App/src-tauri/crates/transcription-engine/src/model_manager.rs
@@ -577,6 +577,17 @@ impl ModelManager {
         Ok((seg_path, emb_path))
     }
 
+    pub async fn ensure_aligner_model(
+        &self,
+        progress: Option<&LabeledProgressFn>,
+        is_cancelled: Option<&(dyn Fn() -> bool + Send + Sync)>,
+    ) -> Result<PathBuf> {
+        let aligner = manifest::aligner();
+        let files: Vec<&str> = aligner.files.iter().map(FileSpec::path).collect();
+        self.ensure_hf_snapshot(&aligner.repo, &files, progress, is_cancelled)
+            .await
+    }
+
     pub fn delete_whisper_model(&self, model: &str) -> Result<()> {
         let cache_dir = self.model_cache_dir()?;
         if !cache_dir.exists() { return Ok(()); }
@@ -772,6 +783,9 @@ impl ModelManager {
     pub fn delete_cached_model(&self, model_name: &str) -> bool {
         if model_name == manifest::diarize().id {
             return self.delete_diarize_model().is_ok();
+        }
+        if model_name == manifest::aligner().id {
+            return self.delete_hf_repo(&manifest::aligner().repo).is_ok();
         }
         match manifest::get(model_name) {
             Some(entry) => match &entry.source {

--- a/AutoSubs-App/src-tauri/crates/transcription-engine/src/types.rs
+++ b/AutoSubs-App/src-tauri/crates/transcription-engine/src/types.rs
@@ -6,12 +6,13 @@ pub enum ProgressType {
     Download,
     Diarize,
     Transcribe,
+    Align,
     Translate,
 }
 
 // Shared callback types
-pub type LabeledProgressFn = dyn Fn(i32, ProgressType, &str) + Send + Sync;     // progress with type and label
-pub type NewSegmentFn = dyn Fn(&Segment) + Send + Sync;           // new segment notifications
+pub type LabeledProgressFn = dyn Fn(i32, ProgressType, &str) + Send + Sync; // progress with type and label
+pub type NewSegmentFn = dyn Fn(&Segment) + Send + Sync; // new segment notifications
 
 #[derive(Clone, Debug, Default)]
 pub struct AdvancedTranscribe {
@@ -45,6 +46,7 @@ pub struct TranscribeOptions {
 
     pub enable_vad: Option<bool>, // Enable Voice Activity Detection to isolate speech segments
     pub enable_diarize: Option<bool>, // Labels segments with speaker_id
+    pub enable_forced_alignment: Option<bool>,
     pub max_speakers: Option<usize>, // Max number of speakers to detect (otherwise auto detection may create too many speakers)
     pub advanced: Option<AdvancedTranscribe>, // Optional knobs
 }
@@ -59,6 +61,7 @@ impl Default for TranscribeOptions {
             translate_target: None,
             enable_vad: Some(true),
             enable_diarize: None,
+            enable_forced_alignment: Some(false),
             max_speakers: None,
             advanced: None,
         }

--- a/AutoSubs-App/src-tauri/src/cli.rs
+++ b/AutoSubs-App/src-tauri/src/cli.rs
@@ -23,7 +23,7 @@ use tauri_plugin_cli::{CliExt, Matches};
 use std::process::Command;
 
 use crate::transcript_types::{Segment, Transcript};
-use crate::transcription_api::{transcribe_audio, FrontendTranscribeOptions};
+use crate::transcription_api::{FrontendTranscribeOptions, transcribe_audio};
 use transcription_engine::TextDensity;
 
 /// Transcription model identifiers accepted by `--model`, grouped by family and
@@ -160,16 +160,29 @@ async fn run_transcribe<R: Runtime>(app: AppHandle<R>, m: Matches) -> ! {
         None => None,
     };
 
+    let translate = arg_flag(&m, "translate");
+    let forced_alignment = arg_flag(&m, "forced-alignment");
+    if translate && forced_alignment {
+        eprintln!("autosubs: --forced-alignment cannot be used with --translate");
+        flush_and_exit(2);
+    }
+    if forced_alignment {
+        eprintln!(
+            "autosubs: MMS forced-alignment weights may be downloaded (317MB); CC BY-NC 4.0, noncommercial use"
+        );
+    }
+
     let options = FrontendTranscribeOptions {
         audio_path: input,
         offset: None,
         model: arg_str(&m, "model").unwrap_or_else(|| "small".to_string()),
         lang: arg_str(&m, "lang"),
-        translate: Some(arg_flag(&m, "translate")),
+        translate: Some(translate),
         target_language: arg_str(&m, "target-language"),
         enable_dtw: None,
         enable_gpu,
         enable_diarize: Some(arg_flag(&m, "diarize")),
+        enable_forced_alignment: Some(forced_alignment),
         max_speakers: arg_num(&m, "max-speakers"),
         density,
         max_lines: arg_num(&m, "max-lines"),
@@ -552,7 +565,10 @@ pub fn cli_command_status() -> CliStatus {
     #[cfg(target_os = "windows")]
     {
         let dir = exe_dir();
-        let installed = dir.as_ref().map(|d| windows_path_contains(d)).unwrap_or(false);
+        let installed = dir
+            .as_ref()
+            .map(|d| windows_path_contains(d))
+            .unwrap_or(false);
         CliStatus {
             installed,
             manageable: true,
@@ -687,7 +703,13 @@ fn windows_path_contains(dir: &std::path::Path) -> bool {
 #[cfg(target_os = "windows")]
 fn run_powershell(script: &str) -> Result<(), String> {
     let out = Command::new("powershell")
-        .args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script])
+        .args([
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            script,
+        ])
         .output()
         .map_err(|e| format!("failed to run PowerShell: {e}"))?;
     if out.status.success() {

--- a/AutoSubs-App/src-tauri/src/tests.rs
+++ b/AutoSubs-App/src-tauri/src/tests.rs
@@ -1,6 +1,6 @@
-use crate::transcription_api::{transcribe_audio, FrontendTranscribeOptions};
-use tauri::test::{mock_builder, mock_context, noop_assets};
+use crate::transcription_api::{FrontendTranscribeOptions, transcribe_audio};
 use std::fs;
+use tauri::test::{mock_builder, mock_context, noop_assets};
 
 #[cfg(test)]
 mod tests {
@@ -28,6 +28,7 @@ mod tests {
             enable_dtw: Some(false),
             enable_gpu: Some(true),
             enable_diarize: Some(false),
+            enable_forced_alignment: Some(false),
             max_speakers: None,
             density: None,
             max_lines: None,
@@ -47,8 +48,8 @@ mod tests {
                 "{}/tests/data/transcript-smoke.json",
                 env!("CARGO_MANIFEST_DIR")
             );
-            let json = serde_json::to_string_pretty(&transcript)
-                .expect("failed to serialize transcript");
+            let json =
+                serde_json::to_string_pretty(&transcript).expect("failed to serialize transcript");
             fs::write(&out_path, json).expect("failed to write transcript file");
             eprintln!("Saved transcript to {}", out_path);
         }
@@ -76,6 +77,7 @@ mod tests {
             enable_dtw: Some(true),
             enable_gpu: Some(true),
             enable_diarize: Some(true),
+            enable_forced_alignment: Some(false),
             max_speakers: None,
             density: None,
             max_lines: None,

--- a/AutoSubs-App/src-tauri/src/transcription_api.rs
+++ b/AutoSubs-App/src-tauri/src/transcription_api.rs
@@ -1,16 +1,19 @@
 use crate::audio_preprocess as audio;
 use crate::models::get_cache_dir;
 use crate::transcript_types::{ColorModifier, Sample, Segment, Speaker, Transcript, WordTimestamp};
+use dirs;
 use eyre::Result;
 use serde::{Deserialize, Serialize};
 use serde_json;
-use dirs;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicI32, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
-use tauri::{command, AppHandle, Emitter, Manager, Runtime};
-use transcription_engine::{Engine, EngineConfig, TranscribeOptions, Callbacks, Segment as WDSegment, ProgressType, PostProcessConfig, process_segments, ContentFormatting, TextCase, TextDensity};
+use tauri::{AppHandle, Emitter, Manager, Runtime, command};
+use transcription_engine::{
+    Callbacks, ContentFormatting, Engine, EngineConfig, PostProcessConfig, ProgressType,
+    Segment as WDSegment, TextCase, TextDensity, TranscribeOptions, process_segments,
+};
 
 // Frontend-compatible progress data type
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -22,7 +25,9 @@ pub struct LabeledProgress {
 }
 
 impl From<(&i32, &Option<ProgressType>, &Option<String>)> for LabeledProgress {
-    fn from((progress, progress_type, label): (&i32, &Option<ProgressType>, &Option<String>)) -> Self {
+    fn from(
+        (progress, progress_type, label): (&i32, &Option<ProgressType>, &Option<String>),
+    ) -> Self {
         Self {
             progress: *progress,
             progress_type: progress_type.as_ref().map(|t| format!("{:?}", t)),
@@ -30,7 +35,6 @@ impl From<(&i32, &Option<ProgressType>, &Option<String>)> for LabeledProgress {
         }
     }
 }
-
 
 // Global cancellation state (public so main.rs can access it for exit handling)
 pub static SHOULD_CANCEL: Mutex<bool> = Mutex::new(false);
@@ -64,6 +68,7 @@ pub struct FrontendTranscribeOptions {
     pub enable_dtw: Option<bool>,
     pub enable_gpu: Option<bool>,
     pub enable_diarize: Option<bool>,
+    pub enable_forced_alignment: Option<bool>,
     pub max_speakers: Option<usize>,
     pub density: Option<TextDensity>,
     pub max_lines: Option<usize>,
@@ -111,6 +116,7 @@ struct TranscribeOptionsLogView<'a> {
     enable_dtw: Option<bool>,
     enable_gpu: Option<bool>,
     enable_diarize: Option<bool>,
+    enable_forced_alignment: Option<bool>,
     max_speakers: Option<usize>,
     density: Option<String>,
     max_lines: Option<usize>,
@@ -136,13 +142,18 @@ impl<'a> From<&'a FrontendTranscribeOptions> for TranscribeOptionsLogView<'a> {
             enable_dtw: o.enable_dtw,
             enable_gpu: o.enable_gpu,
             enable_diarize: o.enable_diarize,
+            enable_forced_alignment: o.enable_forced_alignment,
             max_speakers: o.max_speakers,
             density: o.density.as_ref().map(|d| format!("{:?}", d)),
             max_lines: o.max_lines,
             text_case: o.text_case.as_deref(),
             remove_punctuation: o.remove_punctuation,
             censored_words_count: o.censored_words.as_ref().map(|v| v.len()).unwrap_or(0),
-            custom_prompt_chars: o.custom_prompt.as_deref().map(|v| v.trim().chars().count()).unwrap_or(0),
+            custom_prompt_chars: o
+                .custom_prompt
+                .as_deref()
+                .map(|v| v.trim().chars().count())
+                .unwrap_or(0),
         }
     }
 }
@@ -155,8 +166,12 @@ pub async fn transcribe_audio<R: Runtime>(
     let start_time = Instant::now();
     let options_log = TranscribeOptionsLogView::from(&options);
     match serde_json::to_string(&options_log) {
-        Ok(j) => tracing::info!(target: "autosubs::transcribe", "transcribe_audio: starting options={}", j),
-        Err(_) => tracing::info!(target: "autosubs::transcribe", "transcribe_audio: starting (options failed to serialize)"),
+        Ok(j) => {
+            tracing::info!(target: "autosubs::transcribe", "transcribe_audio: starting options={}", j)
+        }
+        Err(_) => {
+            tracing::info!(target: "autosubs::transcribe", "transcribe_audio: starting (options failed to serialize)")
+        }
     }
 
     // Reset progress and cancellation state
@@ -184,7 +199,7 @@ pub async fn transcribe_audio<R: Runtime>(
                     let progress = LATEST_PROGRESS.load(Ordering::Relaxed).clamp(0, 100);
                     let progress_type = LATEST_PROGRESS_TYPE.lock().unwrap().clone();
                     let progress_label = LATEST_PROGRESS_LABEL.lock().unwrap().clone();
-                    
+
                     if progress != last_progress || progress_type != last_progress_type || progress_label != last_progress_label {
                         // Emit labeled progress with type and label
                         let labeled_progress = LabeledProgress::from((&progress, &progress_type, &progress_label));
@@ -222,6 +237,8 @@ pub async fn transcribe_audio<R: Runtime>(
     // Run transcription using the whisper-diarize-rs crate (it's async)
     let model_name_for_log = options.model.clone();
     let enable_diarize_for_log = options.enable_diarize.unwrap_or(false);
+    let enable_alignment_for_log =
+        options.enable_forced_alignment.unwrap_or(false) && !options.translate.unwrap_or(false);
     let res = async move {
         // Get the proper cache directory for models
         let cache_dir = get_cache_dir(app.clone())
@@ -242,10 +259,15 @@ pub async fn transcribe_audio<R: Runtime>(
                 if enable_diarize_for_log {
                     tracing::info!("diarization enabled (models will be downloaded if missing)");
                 }
+                if enable_alignment_for_log {
+                    let aligner_id = transcription_engine::manifest::aligner().id.as_str();
+                    let cached = models.iter().any(|model| model == aligner_id);
+                    tracing::info!("forced alignment enabled (cached={cached})");
+                }
             }
             Err(e) => tracing::warn!("list_cached_models failed: {}", e),
         }
-        
+
         // Create engine config with proper cache directory
         let engine_config = EngineConfig {
             cache_dir,
@@ -256,8 +278,9 @@ pub async fn transcribe_audio<R: Runtime>(
             vad_model_path: None,             // Use default VAD model
             diarize_segment_model_path: None, // Download segmentation model if needed
             diarize_embedding_model_path: None, // Download embedding model if needed
+            aligner_model_dir: None,
         };
-        
+
         let mut engine = Engine::new(engine_config);
 
         // Map frontend options to crate options
@@ -266,6 +289,9 @@ pub async fn transcribe_audio<R: Runtime>(
         transcribe_options.lang = options.lang.clone().or(Some("auto".into()));
         transcribe_options.enable_vad = Some(true); // Always enable VAD
         transcribe_options.enable_diarize = options.enable_diarize;
+        transcribe_options.enable_forced_alignment = Some(
+            options.enable_forced_alignment.unwrap_or(false) && !options.translate.unwrap_or(false),
+        );
         // Guard against invalid values from the frontend. In the engine, max_speakers == 0
         // effectively prevents creating any speakers and can lead to all segments being labeled "?".
         transcribe_options.max_speakers = match options.max_speakers {
@@ -453,11 +479,7 @@ pub async fn transcribe_audio<R: Runtime>(
             );
 
             // Optional deep-debug dump controlled by env var.
-            if std::env::var("AUTOSUBS_DEBUG_TRANSCRIPT")
-                .ok()
-                .as_deref()
-                == Some("1")
-            {
+            if std::env::var("AUTOSUBS_DEBUG_TRANSCRIPT").ok().as_deref() == Some("1") {
                 match serde_json::to_string_pretty(&transcript) {
                     Ok(json) => tracing::debug!("final transcript JSON:\n{}", json),
                     Err(e) => tracing::warn!("failed to serialize transcript for debug: {}", e),
@@ -475,12 +497,10 @@ pub async fn transcribe_audio<R: Runtime>(
     }
 }
 
-
 /// Always normalize audio to ensure it's mono 16kHz WAV for whisper-diarize-rs
 fn should_normalize(_source: PathBuf) -> bool {
     true
 }
-
 
 // This function must now be `async` because it calls the async `normalize` function.
 /// Expand a leading `~` in a file path to the user's home directory.
@@ -530,7 +550,6 @@ pub async fn create_normalized_audio<R: Runtime>(
 
     Ok(out_path)
 }
-
 
 /// Convert a `transcription_engine` segment to the app's `Segment` type.
 fn wd_to_app_segment(seg: &WDSegment) -> Segment {

--- a/AutoSubs-App/src-tauri/tauri.conf.json
+++ b/AutoSubs-App/src-tauri/tauri.conf.json
@@ -156,6 +156,10 @@
           "takesValue": true
         },
         {
+          "name": "forced-alignment",
+          "description": "Refine word timestamps with the optional MMS forced aligner."
+        },
+        {
           "name": "gpu",
           "description": "Force GPU acceleration on."
         },

--- a/AutoSubs-App/src/components/dialogs/settings-dialog.tsx
+++ b/AutoSubs-App/src/components/dialogs/settings-dialog.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Gauge, Clock, GraduationCap, Terminal } from "lucide-react";
+import { AudioLines, Gauge, Clock, GraduationCap, Terminal } from "lucide-react";
 import { DeleteIcon, type DeleteIconHandle } from "@/components/ui/icons/delete";
 import { useSettingsStore } from "@/stores/settings-store";
 import { ask, message } from "@tauri-apps/plugin-dialog";
@@ -39,6 +39,8 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
   const uiLanguage = useSettingsStore((s) => s.uiLanguage);
   const enableGpu = useSettingsStore((s) => s.enableGpu);
   const enableDTW = useSettingsStore((s) => s.enableDTW);
+  const enableForcedAlignment = useSettingsStore((s) => s.enableForcedAlignment);
+  const translate = useSettingsStore((s) => s.translate);
   const updateSetting = useSettingsStore((s) => s.updateSetting);
   const resetSettings = useSettingsStore((s) => s.resetSettings);
   const { t, i18n } = useTranslation();
@@ -248,6 +250,32 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                       <Switch
                         checked={enableDTW}
                         onCheckedChange={(checked) => updateSetting("enableDTW", checked)}
+                      />
+                    </ItemActions>
+                  </Item>
+                </Field>
+
+                <Field>
+                  <Item variant="outline" size="sm">
+                    <ItemMedia variant="icon" className="bg-purple-100 dark:bg-purple-900/30">
+                      <AudioLines className="size-4 text-purple-600 dark:text-purple-400" />
+                    </ItemMedia>
+                    <ItemContent>
+                      <ItemTitle>{t("settings.forcedAlignment.title")}</ItemTitle>
+                      <ItemDescription className="text-xs leading-tight line-clamp-2">
+                        {translate
+                          ? t("settings.forcedAlignment.translationIncompatible")
+                          : t("settings.forcedAlignment.description")}
+                      </ItemDescription>
+                    </ItemContent>
+                    <ItemActions>
+                      <Switch
+                        checked={enableForcedAlignment}
+                        disabled={translate}
+                        onCheckedChange={(checked) =>
+                          updateSetting("enableForcedAlignment", checked)
+                        }
+                        aria-label={t("settings.forcedAlignment.title")}
                       />
                     </ItemActions>
                   </Item>

--- a/AutoSubs-App/src/components/settings/model-manager.tsx
+++ b/AutoSubs-App/src/components/settings/model-manager.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import { Trash2 } from "lucide-react";
+import { ExternalLink, Trash2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { ask } from "@tauri-apps/plugin-dialog";
 import { Button } from "@/components/ui/button";
@@ -62,8 +62,8 @@ export function ManageModelsDialog({
             </p>
           ) : (
             downloadedModels.map((model) => (
-              <div key={model.value} className="flex items-center justify-between p-3 border rounded-lg">
-                <div className="flex items-center gap-3">
+              <div key={model.value} className="flex items-start justify-between gap-3 p-3 border rounded-lg">
+                <div className="flex min-w-0 items-start gap-3">
                   <img
                     src={model.image}
                     alt={t(model.label)}
@@ -75,6 +75,34 @@ export function ManageModelsDialog({
                       <Badge variant="secondary" className="text-[10px] px-1.5 py-0">{t(model.badge)}</Badge>
                     </div>
                     <p className="text-xs text-muted-foreground">{model.size}</p>
+                    {model.license ? (
+                      <div className="mt-1 space-y-1 text-xs text-muted-foreground">
+                        <p>{t("models.aligner.licenseRestriction")}</p>
+                        <p>{t("models.aligner.attribution")}</p>
+                        <div className="flex flex-wrap gap-x-3 gap-y-1">
+                          {model.repositoryUrl ? (
+                            <a
+                              href={model.repositoryUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="inline-flex items-center gap-1 text-primary hover:underline"
+                            >
+                              {t("models.aligner.repository")}
+                              <ExternalLink className="size-3" />
+                            </a>
+                          ) : null}
+                          <a
+                            href={model.license.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1 text-primary hover:underline"
+                          >
+                            {t("models.aligner.licenseLink")}
+                            <ExternalLink className="size-3" />
+                          </a>
+                        </div>
+                      </div>
+                    ) : null}
                   </div>
                 </div>
                 <Button

--- a/AutoSubs-App/src/components/transcription/run-summary.tsx
+++ b/AutoSubs-App/src/components/transcription/run-summary.tsx
@@ -39,6 +39,7 @@ function useRunSummary(
   const textCase = useSettingsStore((s) => s.textCase);
   const enableGpu = useSettingsStore((s) => s.enableGpu);
   const enableDTW = useSettingsStore((s) => s.enableDTW);
+  const enableForcedAlignment = useSettingsStore((s) => s.enableForcedAlignment);
   const removePunctuation = useSettingsStore((s) => s.removePunctuation);
 
   const sourceModeLabel =
@@ -100,6 +101,9 @@ function useRunSummary(
   }
   if (enableDTW) {
     summaryParts.push(dtwLabel);
+  }
+  if (enableForcedAlignment && !translate) {
+    summaryParts.push(t("settings.forcedAlignment.summary"));
   }
   if (textCase !== "none") {
     summaryParts.push(textCaseLabel);

--- a/AutoSubs-App/src/components/transcription/settings-dropdown.tsx
+++ b/AutoSubs-App/src/components/transcription/settings-dropdown.tsx
@@ -29,7 +29,7 @@ import { SettingsDialog } from "@/components/dialogs/settings-dialog";
 import { SupportDialog } from "@/components/dialogs/support-dialog";
 import { ManageModelsDialog } from "@/components/settings/model-manager";
 import { useModels } from "@/contexts/ModelsContext";
-import { diarizeModel } from "@/lib/models";
+import { alignerModel, diarizeModel } from "@/lib/models";
 import type { Model } from "@/types";
 
 export function SettingsDropdown() {
@@ -43,11 +43,15 @@ export function SettingsDropdown() {
   const [tooltipOpen, setTooltipOpen] = React.useState(false);
   const suppressTooltipUntilRef = React.useRef(0);
 
-  const managerModels: Model[] = downloadedModelValues.includes(
-    diarizeModel.value,
-  )
-    ? [...modelsState, { ...diarizeModel, isDownloaded: true }]
-    : modelsState;
+  const managerModels: Model[] = [
+    ...modelsState,
+    ...(downloadedModelValues.includes(diarizeModel.value)
+      ? [{ ...diarizeModel, isDownloaded: true }]
+      : []),
+    ...(downloadedModelValues.includes(alignerModel.value)
+      ? [{ ...alignerModel, isDownloaded: true }]
+      : []),
+  ];
 
   const handleThemeChange = (themeValue: string) => {
     setTheme(themeValue as "dark" | "light" | "system");

--- a/AutoSubs-App/src/components/transcription/transcription-panel.tsx
+++ b/AutoSubs-App/src/components/transcription/transcription-panel.tsx
@@ -12,7 +12,8 @@ import { useAdobe } from "@/contexts/AdobeContext";
 import { useIntegration } from "@/contexts/IntegrationContext";
 import { useErrorDialog } from "@/contexts/ErrorDialogContext";
 import { ResolveApiError } from "@/api/resolve-api";
-import { diarizeModel } from "@/lib/models";
+import { alignerModel, diarizeModel } from "@/lib/models";
+import { ask } from "@tauri-apps/plugin-dialog";
 import SubSlateCard from "@/components/ui/SubSlateCard";
 import type { TranscriptionOptions } from "@/types";
 import type { SubtitleDocumentListItem } from "@/utils/file-utils";
@@ -53,6 +54,7 @@ export function TranscriptionPanel({
     targetLanguage,
     audioInputMode,
     enableDTW,
+    enableForcedAlignment,
     enableGpu,
     enableDiarize,
     maxSpeakers,
@@ -74,6 +76,7 @@ export function TranscriptionPanel({
       targetLanguage: s.targetLanguage,
       audioInputMode: s.audioInputMode,
       enableDTW: s.enableDTW,
+      enableForcedAlignment: s.enableForcedAlignment,
       enableGpu: s.enableGpu,
       enableDiarize: s.enableDiarize,
       maxSpeakers: s.maxSpeakers,
@@ -219,8 +222,14 @@ export function TranscriptionPanel({
   const isDiarizeModelDownloaded = downloadedModelValues.includes(
     diarizeModel.value,
   );
+  const isAlignerModelDownloaded = downloadedModelValues.includes(
+    alignerModel.value,
+  );
+  const willUseForcedAlignment = enableForcedAlignment && !translate;
   const hasPendingDownloads =
-    !isModelCached || (enableDiarize && !isDiarizeModelDownloaded);
+    !isModelCached ||
+    (enableDiarize && !isDiarizeModelDownloaded) ||
+    (willUseForcedAlignment && !isAlignerModelDownloaded);
 
   React.useEffect(() => {
     const cleanup = setupEventListeners({
@@ -229,6 +238,7 @@ export function TranscriptionPanel({
       isResolveMode: audioInputMode === "timeline",
       hasPendingDownloads,
       enableDiarize,
+      enableForcedAlignment: willUseForcedAlignment,
     });
 
     return cleanup;
@@ -239,6 +249,7 @@ export function TranscriptionPanel({
     audioInputMode,
     hasPendingDownloads,
     enableDiarize,
+    willUseForcedAlignment,
   ]);
 
   React.useEffect(() => {
@@ -327,6 +338,22 @@ export function TranscriptionPanel({
       return;
     }
 
+    if (willUseForcedAlignment && !isAlignerModelDownloaded) {
+      const confirmed = await ask(
+        tErr("settings.forcedAlignment.downloadConfirmationBody", {
+          size: alignerModel.size,
+          attribution: alignerModel.license?.attribution,
+        }),
+        {
+          title: tErr("settings.forcedAlignment.downloadConfirmationTitle"),
+          kind: "warning",
+          okLabel: tErr("settings.forcedAlignment.downloadAndContinue"),
+          cancelLabel: tErr("common.cancel"),
+        },
+      );
+      if (!confirmed) return;
+    }
+
     setIsProcessing(true);
     setTranscriptionProgress(0);
     clearProgressSteps();
@@ -337,6 +364,7 @@ export function TranscriptionPanel({
       isResolveMode: audioInputMode === "timeline",
       hasPendingDownloads,
       enableDiarize,
+      enableForcedAlignment: willUseForcedAlignment,
     });
 
     try {
@@ -361,6 +389,7 @@ export function TranscriptionPanel({
         translate,
         targetLanguage,
         enableDtw: enableDTW,
+        enableForcedAlignment: willUseForcedAlignment,
         enableGpu,
         enableDiarize,
         maxSpeakers,

--- a/AutoSubs-App/src/contexts/ProgressContext.tsx
+++ b/AutoSubs-App/src/contexts/ProgressContext.tsx
@@ -21,7 +21,7 @@ interface ProgressContextType {
   completeAllProgressSteps: () => void;
   cancelAllProgressSteps: () => void;
   updateProgressStep: (event: { progress: number; type?: string; label?: string }) => void;
-  setupEventListeners: (settings: { targetLanguage: string; language: string; isResolveMode?: boolean; hasPendingDownloads?: boolean; enableDiarize?: boolean }) => () => void;
+  setupEventListeners: (settings: { targetLanguage: string; language: string; isResolveMode?: boolean; hasPendingDownloads?: boolean; enableDiarize?: boolean; enableForcedAlignment?: boolean }) => () => void;
 }
 
 const ProgressContext = createContext<ProgressContextType | null>(null);
@@ -34,7 +34,7 @@ export function ProgressProvider({ children }: { children: React.ReactNode }) {
   const seenSegmentsRef = useRef<Set<string>>(new Set());
   
   // Ref to track latest settings for use in closures/callbacks
-  const settingsRef = useRef({ targetLanguage: 'en', language: 'auto', isResolveMode: false, hasPendingDownloads: false, enableDiarize: false });
+  const settingsRef = useRef({ targetLanguage: 'en', language: 'auto', isResolveMode: false, hasPendingDownloads: false, enableDiarize: false, enableForcedAlignment: false });
 
   const resolveProgressLabel = useCallback((label?: string, progress?: number): string => {
     if (!label) {
@@ -56,7 +56,7 @@ export function ProgressProvider({ children }: { children: React.ReactNode }) {
   // Simplified progress step management
   const updateProgressStep = (event: { progress: number, type?: string, label?: string }) => {
     // Only process events with known step types - ignore unknown/null types
-    const knownTypes = ['Export', 'Download', 'Diarize', 'Transcribe', 'Translate']
+    const knownTypes = ['Export', 'Download', 'Diarize', 'Transcribe', 'Align', 'Translate']
     if (!event.type || !knownTypes.includes(event.type)) {
       console.log('Ignoring progress event with unknown type:', event.type)
       return
@@ -151,6 +151,8 @@ export function ProgressProvider({ children }: { children: React.ReactNode }) {
         return i18n.t('progressSteps.diarize');
       case 'Transcribe':
         return i18n.t('progressSteps.transcribe');
+      case 'Align':
+        return i18n.t('progressSteps.align');
       case 'Translate':
         return i18n.t('progressSteps.translate', {
           language: getLanguageDisplayName(settingsRef.current.targetLanguage),
@@ -167,6 +169,7 @@ export function ProgressProvider({ children }: { children: React.ReactNode }) {
     if (settingsRef.current.hasPendingDownloads) order.push('Download')
     if (settingsRef.current.enableDiarize) order.push('Diarize')
     order.push('Transcribe')
+    if (settingsRef.current.enableForcedAlignment) order.push('Align')
     if (settingsRef.current.targetLanguage && settingsRef.current.targetLanguage !== settingsRef.current.language) {
       order.push('Translate')
     }
@@ -219,7 +222,7 @@ export function ProgressProvider({ children }: { children: React.ReactNode }) {
   }
 
   // Set up simplified event listener
-  const setupEventListeners = useCallback((settings: { targetLanguage: string; language: string; isResolveMode?: boolean; hasPendingDownloads?: boolean; enableDiarize?: boolean }) => {
+  const setupEventListeners = useCallback((settings: { targetLanguage: string; language: string; isResolveMode?: boolean; hasPendingDownloads?: boolean; enableDiarize?: boolean; enableForcedAlignment?: boolean }) => {
     // Update settings ref
     settingsRef.current = {
       targetLanguage: settings.targetLanguage,
@@ -227,6 +230,7 @@ export function ProgressProvider({ children }: { children: React.ReactNode }) {
       isResolveMode: settings.isResolveMode ?? false,
       hasPendingDownloads: settings.hasPendingDownloads ?? false,
       enableDiarize: settings.enableDiarize ?? false,
+      enableForcedAlignment: settings.enableForcedAlignment ?? false,
     };
     
     const setup = async () => {

--- a/AutoSubs-App/src/i18n/locales/de/translation.json
+++ b/AutoSubs-App/src/i18n/locales/de/translation.json
@@ -14,6 +14,15 @@
       "title": "Dynamisches Time Warping",
       "description": "Verbessert die Wort-Timing-Genauigkeit"
     },
+    "forcedAlignment": {
+      "title": "Erzwungene Ausrichtung",
+      "description": "Zusätzlichen Timing-Durchlauf ausführen (317-MB-Modell-Download)",
+      "translationIncompatible": "Während der Übersetzung nicht verfügbar, da der übersetzte Text nicht den gesprochenen Wörtern entspricht",
+      "summary": "Erzwungene Ausrichtung",
+      "downloadConfirmationTitle": "Modell für erzwungene Ausrichtung herunterladen?",
+      "downloadConfirmationBody": "AutoSubs lädt das optionale MMS-Modell für erzwungene Ausrichtung ({{size}}) herunter. Namensnennung: {{attribution}}. Die Gewichte sind unter CC BY-NC 4.0 für nichtkommerzielle Nutzung lizenziert und von der MIT-Lizenz von AutoSubs getrennt. Du bist dafür verantwortlich, dass deine Nutzung der Modelllizenz entspricht.",
+      "downloadAndContinue": "Herunterladen und fortfahren"
+    },
     "uiLanguage": {
       "title": "App-Sprache",
       "description": "Aktualisiert Menüs und Buttons"
@@ -221,6 +230,16 @@
       "details": "Wird für Sprecherdiarisierung und Kennzeichnung verwendet.",
       "badge": "Sprecher-Labels"
     },
+    "aligner": {
+      "label": "MMS-Modell für erzwungene Ausrichtung",
+      "description": "Bundle für akustische Wort-Timings",
+      "details": "Optionales Modell, das Transkriptwörter an der Originalsprache ausrichtet.",
+      "badge": "Wort-Timing",
+      "licenseRestriction": "CC BY-NC 4.0 · Nichtkommerziell",
+      "attribution": "Meta MMS-Modell · Upstream-Konvertierung durch MahmoudAshraf · ONNX-Konvertierung durch onnx-community",
+      "repository": "Modell-Repository",
+      "licenseLink": "Modelllizenz"
+    },
     "tiny": {
       "label": "Whisper Tiny",
       "description": "Ultraschnell",
@@ -372,6 +391,7 @@
     "download": "Modell wird geladen",
     "diarize": "Sprecher werden identifiziert",
     "transcribe": "Sprache zu Text",
+    "align": "Wortzeiten werden ausgerichtet",
     "translate": "Übersetze nach {{language}}",
     "normaliseAudio": "Audio wird normalisiert",
     "preparingAudio": "Audio wird vorbereitet...",

--- a/AutoSubs-App/src/i18n/locales/en/translation.json
+++ b/AutoSubs-App/src/i18n/locales/en/translation.json
@@ -14,6 +14,15 @@
       "title": "Dynamic Time Warping",
       "description": "Improve word-level timing accuracy"
     },
+    "forcedAlignment": {
+      "title": "Forced Alignment",
+      "description": "Run an extra timing pass (317MB model download)",
+      "translationIncompatible": "Unavailable during translation because translated text does not match the spoken words",
+      "summary": "Forced alignment",
+      "downloadConfirmationTitle": "Download forced alignment model?",
+      "downloadConfirmationBody": "AutoSubs will download the optional {{size}} MMS forced-alignment model. Attribution: {{attribution}}. The weights are licensed under CC BY-NC 4.0 for noncommercial use and are separate from AutoSubs' MIT license. You are responsible for ensuring your use complies with the model license.",
+      "downloadAndContinue": "Download and continue"
+    },
     "uiLanguage": {
       "title": "App Language",
       "description": "Updates menus and buttons"
@@ -225,6 +234,16 @@
       "details": "Used for speaker diarization and labeling.",
       "badge": "Speaker Labels"
     },
+    "aligner": {
+      "label": "MMS Forced Alignment Model",
+      "description": "Acoustic word timing bundle",
+      "details": "Optional model that aligns transcript words to the original speech.",
+      "badge": "Word Timing",
+      "licenseRestriction": "CC BY-NC 4.0 · Noncommercial",
+      "attribution": "Meta MMS model · upstream conversion by MahmoudAshraf · ONNX conversion by onnx-community",
+      "repository": "Model repository",
+      "licenseLink": "Model license"
+    },
     "tiny": {
       "label": "Whisper Tiny",
       "description": "Ultra-fast",
@@ -376,6 +395,7 @@
     "download": "Downloading model",
     "diarize": "Identifying speakers",
     "transcribe": "Speech to text",
+    "align": "Aligning word timings",
     "translate": "Translating to {{language}}",
     "normaliseAudio": "Normalising audio",
     "preparingAudio": "Preparing audio...",

--- a/AutoSubs-App/src/i18n/locales/es/translation.json
+++ b/AutoSubs-App/src/i18n/locales/es/translation.json
@@ -14,6 +14,15 @@
       "title": "Warping de Tiempo Dinámico",
       "description": "Mejora la precisión del tiempo a nivel de palabra"
     },
+    "forcedAlignment": {
+      "title": "Alineación forzada",
+      "description": "Ejecuta una pasada adicional de tiempos (descarga de modelo de 317 MB)",
+      "translationIncompatible": "No disponible durante la traducción porque el texto traducido no coincide con las palabras pronunciadas",
+      "summary": "Alineación forzada",
+      "downloadConfirmationTitle": "¿Descargar el modelo de alineación forzada?",
+      "downloadConfirmationBody": "AutoSubs descargará el modelo MMS opcional de alineación forzada de {{size}}. Atribución: {{attribution}}. Los pesos tienen licencia CC BY-NC 4.0 para uso no comercial y están separados de la licencia MIT de AutoSubs. Eres responsable de garantizar que tu uso cumpla la licencia del modelo.",
+      "downloadAndContinue": "Descargar y continuar"
+    },
     "uiLanguage": {
       "title": "Idioma de la aplicación",
       "description": "Actualiza menús y botones"
@@ -221,6 +230,16 @@
       "details": "Se utiliza para la diarización y el etiquetado de hablantes.",
       "badge": "Etiquetas de hablante"
     },
+    "aligner": {
+      "label": "Modelo MMS de alineación forzada",
+      "description": "Paquete de tiempos acústicos por palabra",
+      "details": "Modelo opcional que alinea las palabras de la transcripción con el habla original.",
+      "badge": "Tiempos de palabras",
+      "licenseRestriction": "CC BY-NC 4.0 · No comercial",
+      "attribution": "Modelo MMS de Meta · conversión original de MahmoudAshraf · conversión ONNX de onnx-community",
+      "repository": "Repositorio del modelo",
+      "licenseLink": "Licencia del modelo"
+    },
     "tiny": {
       "label": "Whisper Diminuto",
       "description": "Ultra-rápido",
@@ -372,6 +391,7 @@
     "download": "Descargando modelo",
     "diarize": "Identificando hablantes",
     "transcribe": "Voz a texto",
+    "align": "Alineando tiempos de palabras",
     "translate": "Traduciendo a {{language}}",
     "normaliseAudio": "Normalizando audio",
     "preparingAudio": "Preparando audio...",

--- a/AutoSubs-App/src/i18n/locales/fr/translation.json
+++ b/AutoSubs-App/src/i18n/locales/fr/translation.json
@@ -14,6 +14,15 @@
       "title": "Alignement temporel dynamique",
       "description": "Améliorer la précision du minutage au niveau des mots"
     },
+    "forcedAlignment": {
+      "title": "Alignement forcé",
+      "description": "Effectuer une passe de minutage supplémentaire (téléchargement d’un modèle de 317 Mo)",
+      "translationIncompatible": "Indisponible pendant la traduction, car le texte traduit ne correspond pas aux mots prononcés",
+      "summary": "Alignement forcé",
+      "downloadConfirmationTitle": "Télécharger le modèle d’alignement forcé ?",
+      "downloadConfirmationBody": "AutoSubs téléchargera le modèle MMS facultatif d’alignement forcé de {{size}}. Attribution : {{attribution}}. Les poids sont sous licence CC BY-NC 4.0 pour un usage non commercial et sont distincts de la licence MIT d’AutoSubs. Il vous incombe de vérifier que votre utilisation respecte la licence du modèle.",
+      "downloadAndContinue": "Télécharger et continuer"
+    },
     "uiLanguage": {
       "title": "Langue de l’application",
       "description": "Met à jour menus et boutons"
@@ -221,6 +230,16 @@
       "details": "Utilisé pour la diarisation et l’étiquetage des intervenants.",
       "badge": "Labels de speaker"
     },
+    "aligner": {
+      "label": "Modèle MMS d’alignement forcé",
+      "description": "Pack de minutage acoustique des mots",
+      "details": "Modèle facultatif qui aligne les mots de la transcription sur la parole originale.",
+      "badge": "Minutage des mots",
+      "licenseRestriction": "CC BY-NC 4.0 · Non commercial",
+      "attribution": "Modèle MMS de Meta · conversion d’origine par MahmoudAshraf · conversion ONNX par onnx-community",
+      "repository": "Dépôt du modèle",
+      "licenseLink": "Licence du modèle"
+    },
     "tiny": {
       "label": "Whisper Tiny",
       "description": "Ultra-rapide",
@@ -372,6 +391,7 @@
     "download": "Téléchargement du modèle",
     "diarize": "Identification des intervenants",
     "transcribe": "Voix en texte",
+    "align": "Alignement des mots",
     "translate": "Traduction vers {{language}}",
     "normaliseAudio": "Normalisation de l'audio",
     "preparingAudio": "Préparation de l'audio...",

--- a/AutoSubs-App/src/i18n/locales/ja/translation.json
+++ b/AutoSubs-App/src/i18n/locales/ja/translation.json
@@ -254,6 +254,16 @@
       "details": "話者のダイアリゼーションとラベリングに使用されます。",
       "badge": "話者ラベル"
     },
+    "aligner": {
+      "label": "MMS 強制アライメントモデル",
+      "description": "音声に基づく単語タイミングモデル",
+      "details": "文字起こしの単語を元の音声に合わせるオプションモデルです。",
+      "badge": "単語タイミング",
+      "licenseRestriction": "CC BY-NC 4.0 · 非商用",
+      "attribution": "Meta MMS モデル。MahmoudAshraf および onnx-community による変換。",
+      "repository": "モデルリポジトリ",
+      "licenseLink": "モデルライセンス"
+    },
     "moonshine_base": {
       "badge": "英語専用",
       "description": "高速・高精度",
@@ -374,6 +384,7 @@
     "diarize": "話者を識別中",
     "processing": "処理中",
     "transcribe": "音声をテキストに変換中",
+    "align": "単語タイミングを調整中",
     "translate": "{{language}} に翻訳中",
     "normaliseAudio": "音声を正規化中",
     "preparingAudio": "音声を準備中...",
@@ -384,6 +395,15 @@
     "dtw": {
       "description": "単語レベルのタイミング精度を向上",
       "title": "動的時間伸縮法"
+    },
+    "forcedAlignment": {
+      "title": "強制アライメント",
+      "description": "追加のタイミング処理を実行（317MB のモデルをダウンロード）",
+      "translationIncompatible": "翻訳文は音声で話された単語と一致しないため、翻訳中は利用できません",
+      "summary": "強制アライメント",
+      "downloadConfirmationTitle": "強制アライメントモデルをダウンロードしますか？",
+      "downloadConfirmationBody": "AutoSubs はオプションの {{size}} MMS 強制アライメントモデルをダウンロードします。帰属表示：{{attribution}}。モデルの重みは非商用利用に限る CC BY-NC 4.0 でライセンスされ、AutoSubs の MIT ライセンスとは別です。モデルライセンスに準拠して利用する責任はユーザーにあります。",
+      "downloadAndContinue": "ダウンロードして続行"
     },
     "restartOnboarding": "オンボーディングを再開",
     "openLogsFolder": "ログフォルダを開く",

--- a/AutoSubs-App/src/i18n/locales/ko/translation.json
+++ b/AutoSubs-App/src/i18n/locales/ko/translation.json
@@ -246,6 +246,16 @@
       "details": "화자 분리 및 라벨링에 사용됩니다.",
       "label": "화자 분리 모델"
     },
+    "aligner": {
+      "label": "MMS 강제 정렬 모델",
+      "description": "음향 기반 단어 타이밍 모델",
+      "details": "자막 단어를 원본 음성에 맞추는 선택적 모델입니다.",
+      "badge": "단어 타이밍",
+      "licenseRestriction": "CC BY-NC 4.0 · 비상업적 사용",
+      "attribution": "Meta MMS 모델. MahmoudAshraf 및 onnx-community가 변환했습니다.",
+      "repository": "모델 저장소",
+      "licenseLink": "모델 라이선스"
+    },
     "manage": {
       "confirmBody": "{{model}} 모델을 기기에서 삭제합니다. 나중에 이 모델을 사용하면 다시 다운로드해야 합니다.",
       "confirmTitle": "정말 삭제하시겠습니까?",
@@ -374,6 +384,7 @@
     "diarize": "화자 식별 중",
     "processing": "처리 중",
     "transcribe": "음성을 텍스트로 변환 중",
+    "align": "단어 타이밍 정렬 중",
     "translate": "{{language}}(으)로 번역 중",
     "normaliseAudio": "오디오 정규화 중",
     "preparingAudio": "오디오 준비 중...",
@@ -384,6 +395,15 @@
     "dtw": {
       "description": "단어 수준 타이밍 정확도 향상",
       "title": "동적 시간 왜곡"
+    },
+    "forcedAlignment": {
+      "title": "강제 정렬",
+      "description": "추가 타이밍 처리 실행(317MB 모델 다운로드)",
+      "translationIncompatible": "번역된 텍스트는 음성으로 말한 단어와 일치하지 않으므로 번역 중에는 사용할 수 없습니다",
+      "summary": "강제 정렬",
+      "downloadConfirmationTitle": "강제 정렬 모델을 다운로드하시겠습니까?",
+      "downloadConfirmationBody": "AutoSubs가 선택 사항인 {{size}} MMS 강제 정렬 모델을 다운로드합니다. 저작자 표시: {{attribution}}. 모델 가중치는 비상업적 사용을 위한 CC BY-NC 4.0 라이선스이며 AutoSubs의 MIT 라이선스와 별개입니다. 모델 라이선스를 준수하여 사용할 책임은 사용자에게 있습니다.",
+      "downloadAndContinue": "다운로드하고 계속"
     },
     "restartOnboarding": "온보딩 다시 시작",
     "openLogsFolder": "로그 폴더 열기",

--- a/AutoSubs-App/src/i18n/locales/zh/translation.json
+++ b/AutoSubs-App/src/i18n/locales/zh/translation.json
@@ -14,6 +14,15 @@
       "title": "动态时间规整",
       "description": "提高词级时间准确性"
     },
+    "forcedAlignment": {
+      "title": "强制对齐",
+      "description": "执行额外的时间校准（需下载 317MB 模型）",
+      "translationIncompatible": "翻译时不可用，因为译文与音频中说出的词语不一致",
+      "summary": "强制对齐",
+      "downloadConfirmationTitle": "下载强制对齐模型？",
+      "downloadConfirmationBody": "AutoSubs 将下载可选的 {{size}} MMS 强制对齐模型。署名：{{attribution}}。模型权重采用 CC BY-NC 4.0 许可，仅限非商业用途，并独立于 AutoSubs 的 MIT 许可证。您有责任确保自己的使用方式符合模型许可证。",
+      "downloadAndContinue": "下载并继续"
+    },
     "uiLanguage": {
       "title": "应用语言",
       "description": "更新菜单和按钮"
@@ -221,6 +230,16 @@
       "details": "用于说话人分离和标注。",
       "badge": "说话人标签"
     },
+    "aligner": {
+      "label": "MMS 强制对齐模型",
+      "description": "词语声学时间校准包",
+      "details": "将转录词语与原始语音对齐的可选模型。",
+      "badge": "词语时间",
+      "licenseRestriction": "CC BY-NC 4.0 · 仅限非商业用途",
+      "attribution": "Meta MMS 模型 · MahmoudAshraf 上游转换 · onnx-community ONNX 转换",
+      "repository": "模型仓库",
+      "licenseLink": "模型许可证"
+    },
     "tiny": {
       "label": "Whisper 微型",
       "description": "超快速",
@@ -372,6 +391,7 @@
     "download": "正在下载模型",
     "diarize": "正在识别说话人",
     "transcribe": "语音转文本",
+    "align": "正在对齐单词时间",
     "translate": "正在翻译为 {{language}}",
     "normaliseAudio": "正在标准化音频",
     "preparingAudio": "正在准备音频...",

--- a/AutoSubs-App/src/lib/models.ts
+++ b/AutoSubs-App/src/lib/models.ts
@@ -28,9 +28,24 @@ interface ManifestModel {
   ui: ManifestUi;
 }
 
+interface ManifestLicense {
+  spdx: string;
+  url: string;
+  attribution: string;
+  commercialUse: boolean;
+}
+
+interface ManifestAuxiliaryModel {
+  id: string;
+  repo: string;
+  ui: ManifestUi;
+  license?: ManifestLicense;
+}
+
 interface ManifestFile {
   models: ManifestModel[];
-  diarize: { id: string; ui: ManifestUi };
+  diarize: ManifestAuxiliaryModel;
+  aligner: ManifestAuxiliaryModel;
 }
 
 const manifest = manifestData as unknown as ManifestFile;
@@ -109,6 +124,17 @@ export const diarizeModel: Model = toModel(
   manifest.diarize.ui,
   "diarize"
 );
+
+export const alignerModel: Model = {
+  ...toModel(
+    manifest.aligner.id,
+    "aligner",
+    manifest.aligner.ui,
+    "aligner"
+  ),
+  repositoryUrl: `https://huggingface.co/${manifest.aligner.repo}`,
+  license: manifest.aligner.license,
+};
 
 /**
  * Check if a model's engine supports automatic language detection.

--- a/AutoSubs-App/src/stores/settings-store.ts
+++ b/AutoSubs-App/src/stores/settings-store.ts
@@ -44,6 +44,7 @@ export const DEFAULT_SETTINGS: Settings = {
   translate: false,
   targetLanguage: "en",
   enableDTW: true, // gpu enabled by default on mac and linux, disabled by default on windows
+  enableForcedAlignment: false,
   enableGpu: true,
   enableDiarize: false,
   maxSpeakers: null,

--- a/AutoSubs-App/src/types.ts
+++ b/AutoSubs-App/src/types.ts
@@ -81,6 +81,13 @@ export interface Model {
     accuracy: 1 | 2 | 3 | 4 // 1 = Poor, 2 = Standard, 3 = Excellent, 4 = Best-in-class
     weight: 1 | 2 | 3 | 4 // 1 = Very Heavy, 2 = Heavy, 3 = Standard, 4 = Lightweight
     isDownloaded: boolean
+    repositoryUrl?: string
+    license?: {
+        spdx: string
+        url: string
+        attribution: string
+        commercialUse: boolean
+    }
 }
 
 // Settings Interface
@@ -113,6 +120,7 @@ export interface Settings {
     enableDiarize: boolean,
     maxSpeakers: number | null,
     enableDTW: boolean,
+    enableForcedAlignment: boolean,
     enableGpu: boolean,
 
     // Text settings
@@ -175,6 +183,7 @@ export interface TranscriptionOptions {
     translate: boolean,
     targetLanguage: string,
     enableDtw: boolean,
+    enableForcedAlignment: boolean,
     enableGpu: boolean,
     enableDiarize: boolean,
     maxSpeakers: number | null,

--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ AutoSubs code is MIT-licensed. The optional MMS forced-alignment weights are dow
 
 The forced-aligner weights originate from Meta's MMS model, with forced-alignment conversion work by MahmoudAshraf and ONNX/INT8 conversion by [onnx-community](https://huggingface.co/onnx-community/mms-300m-1130-forced-aligner-ONNX). Conversion and quantization changes were made by those respective projects; no endorsement is implied.
 
+While MMS supports over a thousand languages, word-level alignment relies on romanizing the transcript with [uroman](https://github.com/o24s/uroman-rs). uroman covers the major world scripts (Latin, Cyrillic, Arabic, CJK, most Indic scripts, etc.), but very low-resource minority languages whose scripts are not included in its data may produce degraded or missing word timestamps.
+
 ## Acknowledgments
 
 AutoSubs is built on top of excellent open-source projects:

--- a/README.md
+++ b/README.md
@@ -195,6 +195,12 @@ For detailed information about the DaVinci Resolve integration architecture, Lua
 
 ---
 
+## Model licensing
+
+AutoSubs code is MIT-licensed. The optional MMS forced-alignment weights are downloaded separately and licensed under [CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/) for noncommercial use. Users are responsible for ensuring their use complies with the model license.
+
+The forced-aligner weights originate from Meta's MMS model, with forced-alignment conversion work by MahmoudAshraf and ONNX/INT8 conversion by [onnx-community](https://huggingface.co/onnx-community/mms-300m-1130-forced-aligner-ONNX). Conversion and quantization changes were made by those respective projects; no endorsement is implied.
+
 ## Acknowledgments
 
 AutoSubs is built on top of excellent open-source projects:


### PR DESCRIPTION
Introduce an opt-in forced-alignment pass that refines source-language word timings after transcription, with on-demand model download, CC BY-NC licensing guards, and UI/CLI wiring that disables the feature during translation.

Followed the detailed plan at `/plans/forced-aligner-integration.md`

### What landed
- **Core engine**: new `align.rs` with MMS CTC forced alignment (normalization, chunked ONNX emissions, Viterbi, romanization via `uroman`, span → word timestamps)
- **Pipeline**: runs after transcription / language detection and before formatting; disabled when translation is on
- **Model lifecycle**: `models.json` aligner bundle + license metadata; download/list/delete via existing manager paths
- **API/CLI**: `enableForcedAlignment` / `--forced-alignment`, with hard reject/skip for translation combinations
- **UI**: settings toggle, download license confirmation, pending-download handling, progress `Align` stage, model manager license display, run-summary, all locales
- **Docs**: README model-license notice (CC BY-NC 4.0)

### Verification
- `cargo check -p transcription-engine --features mac-aarch` ✅
- `cargo test -p transcription-engine --features mac-aarch --lib` ✅ (`53` passed, `1` ignored)
- `cargo check --features mac-aarch` (full app) ✅
- `npm run build:web` ✅

### Notes / follow-ups
- Golden unit coverage is in place for core align logic; full end-to-end accuracy vs Python `ctc-forced-aligner` and EP benchmarks still remain as later validation work from the plan.
- Reused existing `diarize.png` for the aligner card (no new asset).