### PR TITLE
feat(models): add GigaAM v3 for Russian transcription

### DIFF
--- a/AutoSubs-App/models.json
+++ b/AutoSubs-App/models.json
@@ -256,6 +256,21 @@
       "ui": { "size": "2GB", "ram": "4GB", "image": "moose.png", "accuracy": 4, "weight": 1, "languageSupport": { "kind": "restricted", "languages": ["ar", "de", "el", "en", "es", "fr", "it", "ja", "ko", "nl", "pl", "pt", "vi", "zh"] } }
     },
     {
+      "id": "gigaam-v3",
+      "engine": "gigaam",
+      "quantization": "int8",
+      "_files_comment": "The GigaAM loader resolves model[.int8].onnx and vocab.txt inside the model dir, so the repo files are renamed on download. The e2e CTC variant is used because it emits punctuated, normalized text.",
+      "source": {
+        "type": "hf",
+        "repo": "istupakov/gigaam-v3-onnx",
+        "files": [
+          { "path": "v3_e2e_ctc.int8.onnx", "dest": "model.int8.onnx" },
+          { "path": "v3_e2e_ctc_vocab.txt", "dest": "vocab.txt" }
+        ]
+      },
+      "ui": { "size": "225MB", "ram": "2GB", "image": "owl.png", "accuracy": 4, "weight": 3, "languageSupport": { "kind": "restricted", "languages": ["ru", "en"] } }
+    },
+    {
       "id": "omni-asr-1b-ctc",
       "engine": "omni_asr",
       "quantization": "fp32",

--- a/AutoSubs-App/src-tauri/crates/transcription-engine/src/engines/gigaam.rs
+++ b/AutoSubs-App/src-tauri/crates/transcription-engine/src/engines/gigaam.rs
@@ -1,0 +1,82 @@
+//! GigaAM (Sber) Russian speech recognition backend.
+
+use crate::engines::onnx::{run_onnx_pipeline, OnnxEngine, WordTiming};
+use crate::types::{LabeledProgressFn, NewSegmentFn, ProgressType, Segment, SpeechSegment, TranscribeOptions};
+use eyre::{eyre, Result};
+use std::path::Path;
+use transcribe_rs::onnx::{
+    gigaam::{GigaAMModel, GigaAMParams},
+    Quantization,
+};
+use transcribe_rs::TranscriptionResult;
+
+pub struct GigaamEngine {
+    model: GigaAMModel,
+    params: GigaAMParams,
+}
+
+impl OnnxEngine for GigaamEngine {
+    // The Conformer encoder attends over the whole chunk, so memory grows
+    // quadratically with its length; cap it like the other ONNX engines.
+    const MAX_SEGMENT_SECONDS: f64 = 25.0;
+
+    fn load(model_path: &Path) -> Result<Self> {
+        let model = GigaAMModel::load(model_path, &Quantization::Int8)
+            .map_err(|e| eyre!("Failed to load GigaAM model: {}", e))?;
+
+        Ok(Self {
+            model,
+            params: GigaAMParams::default(),
+        })
+    }
+
+    fn transcribe_chunk(&mut self, samples: &[f32]) -> Result<TranscriptionResult> {
+        self.model
+            .transcribe_with(samples, &self.params)
+            .map_err(|e| eyre!("GigaAM transcription failed: {}", e))
+    }
+
+    // The CTC head emits no token timings, so word boundaries are spread
+    // across the chunk window and refined later by the optional aligner.
+    fn word_timing(&self) -> WordTiming {
+        WordTiming::Interpolated
+    }
+
+    fn detected_lang(&self) -> Option<String> {
+        None
+    }
+}
+
+pub async fn transcribe_gigaam(
+    model_path: &Path,
+    speech_segments: Vec<SpeechSegment>,
+    options: &TranscribeOptions,
+    use_gpu: Option<bool>,
+    progress_callback: Option<&LabeledProgressFn>,
+    new_segment_callback: Option<&NewSegmentFn>,
+    abort_callback: Option<Box<dyn Fn() -> bool + Send + Sync>>,
+) -> Result<(Vec<Segment>, Option<String>)> {
+    tracing::debug!("GigaAM transcribe called with model: {:?}", model_path);
+
+    if abort_callback.as_ref().map(|c| c()).unwrap_or(false) {
+        eyre::bail!("Transcription cancelled");
+    }
+
+    if let Some(cb) = progress_callback {
+        cb(0, ProgressType::Analyze, "progressSteps.analyze.loading");
+    }
+    let engine = crate::engines::onnx::load_with_directml_fallback(use_gpu, || GigaamEngine::load(model_path))?;
+    if let Some(cb) = progress_callback {
+        cb(100, ProgressType::Analyze, "progressSteps.analyze.loading");
+    }
+
+    run_onnx_pipeline(
+        engine,
+        speech_segments,
+        options.offset.unwrap_or(0.0),
+        progress_callback,
+        new_segment_callback,
+        abort_callback,
+    )
+    .await
+}

--- a/AutoSubs-App/src-tauri/crates/transcription-engine/src/engines/mod.rs
+++ b/AutoSubs-App/src-tauri/crates/transcription-engine/src/engines/mod.rs
@@ -5,6 +5,7 @@
 //! - **Parakeet**: NVIDIA's NeMo Parakeet model via transcribe-rs (ONNX format)
 //! - **Moonshine**: Useful Sensors' Moonshine via transcribe-rs (ONNX format)
 //! - **SenseVoice**: FunAudioLLM SenseVoice via transcribe-rs (ONNX format)
+//! - **GigaAM**: Sber's Russian GigaAM v3 CTC via transcribe-rs (ONNX format)
 //! - **OmniAsr**: Facebook Omni-ASR 300M CTC via ORT (ONNX format)
 
 use crate::engine::EngineConfig;
@@ -18,6 +19,7 @@ pub mod whisper;
 pub mod onnx;
 pub mod canary;
 pub mod cohere;
+pub mod gigaam;
 pub mod moonshine;
 pub mod omni_asr;
 pub mod parakeet;
@@ -28,6 +30,7 @@ pub use whisper::{create_context, run_transcription_pipeline, SHOULD_CANCEL};
 
 pub use canary::transcribe_canary;
 pub use cohere::transcribe_cohere;
+pub use gigaam::transcribe_gigaam;
 pub use moonshine::transcribe_moonshine;
 pub use parakeet::transcribe_parakeet;
 pub use omni_asr::transcribe_omni_asr;
@@ -149,6 +152,18 @@ pub async fn run_engine(
             )
             .await
         }
+        ModelEngine::Gigaam => {
+            crate::engines::gigaam::transcribe_gigaam(
+                model_path,
+                speech_segments,
+                options,
+                use_gpu,
+                progress,
+                new_segment_callback,
+                abort_callback,
+            )
+            .await
+        }
         ModelEngine::OmniAsr => {
             crate::engines::omni_asr::transcribe_omni_asr(
                 model_path,
@@ -161,10 +176,5 @@ pub async fn run_engine(
             )
             .await
         }
-        other => Err(eyre!(
-            "Transcription engine {:?} (model '{}') is not yet supported",
-            other,
-            options.model
-        )),
     }
 }

--- a/AutoSubs-App/src-tauri/crates/transcription-engine/src/manifest.rs
+++ b/AutoSubs-App/src-tauri/crates/transcription-engine/src/manifest.rs
@@ -379,6 +379,7 @@ mod tests {
                         | Engine::SenseVoice
                         | Engine::Canary
                         | Engine::Cohere
+                        | Engine::Gigaam
                         | Engine::OmniAsr
                 ),
                 "model '{}' uses engine {:?} which has no wrapper yet",

--- a/AutoSubs-App/src-tauri/src/cli.rs
+++ b/AutoSubs-App/src-tauri/src/cli.rs
@@ -44,6 +44,8 @@ const MODELS: &[&str] = &[
     "large-v3",
     // Parakeet
     "parakeet",
+    // GigaAM
+    "gigaam-v3",
     // Omni-ASR
     "omni-asr-1b-ctc",
     // Moonshine

--- a/AutoSubs-App/src/i18n/locales/de/translation.json
+++ b/AutoSubs-App/src/i18n/locales/de/translation.json
@@ -380,9 +380,9 @@
     },
     "gigaam_v3": {
       "label": "GigaAM v3",
-      "description": "Best for Russian",
-      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
-      "badge": "Russian"
+      "description": "Am besten für Russisch",
+      "details": "Trainiert mit 700.000 Stunden russischer Sprache, mit Zeichensetzung und Textnormalisierung. Die genaueste Option für Russisch.",
+      "badge": "Russisch"
     },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",

--- a/AutoSubs-App/src/i18n/locales/de/translation.json
+++ b/AutoSubs-App/src/i18n/locales/de/translation.json
@@ -378,6 +378,12 @@
       "details": "Großes mehrsprachiges Transkriptionsmodell von Cohere.",
       "badge": "Mehrsprachig"
     },
+    "gigaam_v3": {
+      "label": "GigaAM v3",
+      "description": "Best for Russian",
+      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
+      "badge": "Russian"
+    },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",
       "description": "On-device Multilingual",

--- a/AutoSubs-App/src/i18n/locales/en/translation.json
+++ b/AutoSubs-App/src/i18n/locales/en/translation.json
@@ -382,6 +382,12 @@
       "details": "Large multilingual transcription model from Cohere.",
       "badge": "Multilingual"
     },
+    "gigaam_v3": {
+      "label": "GigaAM v3",
+      "description": "Best for Russian",
+      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
+      "badge": "Russian"
+    },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",
       "description": "On-device Multilingual",

--- a/AutoSubs-App/src/i18n/locales/es/translation.json
+++ b/AutoSubs-App/src/i18n/locales/es/translation.json
@@ -380,9 +380,9 @@
     },
     "gigaam_v3": {
       "label": "GigaAM v3",
-      "description": "Best for Russian",
-      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
-      "badge": "Russian"
+      "description": "Ideal para ruso",
+      "details": "Entrenado con 700 000 horas de habla rusa, con puntuación y normalización de texto. La opción más precisa para el ruso.",
+      "badge": "Ruso"
     },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",

--- a/AutoSubs-App/src/i18n/locales/es/translation.json
+++ b/AutoSubs-App/src/i18n/locales/es/translation.json
@@ -378,6 +378,12 @@
       "details": "Modelo grande de transcripción multilingüe de Cohere.",
       "badge": "Multilingüe"
     },
+    "gigaam_v3": {
+      "label": "GigaAM v3",
+      "description": "Best for Russian",
+      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
+      "badge": "Russian"
+    },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",
       "description": "On-device Multilingual",

--- a/AutoSubs-App/src/i18n/locales/fr/translation.json
+++ b/AutoSubs-App/src/i18n/locales/fr/translation.json
@@ -378,6 +378,12 @@
       "details": "Grand modèle de transcription multilingue de Cohere.",
       "badge": "Multilingue"
     },
+    "gigaam_v3": {
+      "label": "GigaAM v3",
+      "description": "Best for Russian",
+      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
+      "badge": "Russian"
+    },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",
       "description": "On-device Multilingual",

--- a/AutoSubs-App/src/i18n/locales/fr/translation.json
+++ b/AutoSubs-App/src/i18n/locales/fr/translation.json
@@ -380,9 +380,9 @@
     },
     "gigaam_v3": {
       "label": "GigaAM v3",
-      "description": "Best for Russian",
-      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
-      "badge": "Russian"
+      "description": "Idéal pour le russe",
+      "details": "Entraîné sur 700 000 heures de parole russe, avec ponctuation et normalisation du texte. L'option la plus précise pour le russe.",
+      "badge": "Russe"
     },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",

--- a/AutoSubs-App/src/i18n/locales/ja/translation.json
+++ b/AutoSubs-App/src/i18n/locales/ja/translation.json
@@ -378,6 +378,12 @@
       "details": "Cohere の大型多言語文字起こしモデル。",
       "label": "Cohere"
     },
+    "gigaam_v3": {
+      "label": "GigaAM v3",
+      "description": "Best for Russian",
+      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
+      "badge": "Russian"
+    },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",
       "description": "On-device Multilingual",

--- a/AutoSubs-App/src/i18n/locales/ja/translation.json
+++ b/AutoSubs-App/src/i18n/locales/ja/translation.json
@@ -380,9 +380,9 @@
     },
     "gigaam_v3": {
       "label": "GigaAM v3",
-      "description": "Best for Russian",
-      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
-      "badge": "Russian"
+      "description": "ロシア語に最適",
+      "details": "70万時間のロシア語音声で学習。句読点とテキスト正規化に対応した、ロシア語で最も高精度な選択肢。",
+      "badge": "ロシア語"
     },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",

--- a/AutoSubs-App/src/i18n/locales/ko/translation.json
+++ b/AutoSubs-App/src/i18n/locales/ko/translation.json
@@ -378,6 +378,12 @@
       "details": "Cohere의 대형 다국어 자막 생성 모델.",
       "label": "Cohere"
     },
+    "gigaam_v3": {
+      "label": "GigaAM v3",
+      "description": "Best for Russian",
+      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
+      "badge": "Russian"
+    },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",
       "description": "On-device Multilingual",

--- a/AutoSubs-App/src/i18n/locales/ko/translation.json
+++ b/AutoSubs-App/src/i18n/locales/ko/translation.json
@@ -380,9 +380,9 @@
     },
     "gigaam_v3": {
       "label": "GigaAM v3",
-      "description": "Best for Russian",
-      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
-      "badge": "Russian"
+      "description": "러시아어에 최적",
+      "details": "70만 시간의 러시아어 음성으로 학습. 문장 부호와 텍스트 정규화를 지원하는 러시아어에 가장 정확한 모델.",
+      "badge": "러시아어"
     },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",

--- a/AutoSubs-App/src/i18n/locales/zh/translation.json
+++ b/AutoSubs-App/src/i18n/locales/zh/translation.json
@@ -378,6 +378,12 @@
       "details": "Cohere 的大型多语言转录模型。",
       "badge": "多语言"
     },
+    "gigaam_v3": {
+      "label": "GigaAM v3",
+      "description": "Best for Russian",
+      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
+      "badge": "Russian"
+    },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",
       "description": "On-device Multilingual",

--- a/AutoSubs-App/src/i18n/locales/zh/translation.json
+++ b/AutoSubs-App/src/i18n/locales/zh/translation.json
@@ -380,9 +380,9 @@
     },
     "gigaam_v3": {
       "label": "GigaAM v3",
-      "description": "Best for Russian",
-      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
-      "badge": "Russian"
+      "description": "俄语最佳",
+      "details": "基于 70 万小时俄语语音训练，支持标点和文本规范化。俄语的最准确选择。",
+      "badge": "俄语"
     },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",

--- a/AutoSubs-App/src/lib/models.ts
+++ b/AutoSubs-App/src/lib/models.ts
@@ -86,7 +86,7 @@ export const modelFilterOrders = {
     "moonshine-tiny-ko", "moonshine-tiny-uk", "moonshine-tiny-vi",
     "moonshine-base", "sense-voice",
     // 2GB RAM
-    "small.en", "small", "parakeet",
+    "small.en", "small", "parakeet", "gigaam-v3",
     // 3-4GB RAM
     "canary", "cohere", "omni-asr-1b-ctc",
     // 5-6GB RAM
@@ -95,14 +95,14 @@ export const modelFilterOrders = {
     "large-v3"
   ],
   accuracy: [
-    "cohere", "parakeet", "canary", "large-v3", "large-v3-turbo",
+    "cohere", "parakeet", "canary", "gigaam-v3", "large-v3", "large-v3-turbo",
     "moonshine-tiny-vi", "moonshine-tiny-ar", "moonshine-tiny-zh", "moonshine-tiny-ja", "moonshine-tiny-ko", "medium.en", "medium",
     "sense-voice", "moonshine-base", "small.en", "small", "moonshine-tiny-uk",
     "omni-asr-1b-ctc",
     "tiny", "tiny.en", "base", "base.en", "moonshine-tiny"
   ],
   recommended: [
-    "parakeet", "canary", "sense-voice", "omni-asr-1b-ctc", "cohere", "large-v3-turbo", "large-v3",
+    "parakeet", "canary", "sense-voice", "gigaam-v3", "omni-asr-1b-ctc", "cohere", "large-v3-turbo", "large-v3",
     "moonshine-tiny-ar", "moonshine-tiny-zh", "moonshine-tiny-ja", "moonshine-tiny-ko", "moonshine-tiny-uk", "moonshine-tiny-vi",
     "moonshine-base", "small.en", "small",
     "medium", "medium.en",

--- a/README.md
+++ b/README.md
@@ -159,6 +159,14 @@ Cohere Transcribe (int4 ONNX). The highest-accuracy option for a focused set of 
 |---|---|---|---|---|
 | cohere | 2 GB | 4 GB | Arabic, German, Greek, English, Spanish, French, Italian, Japanese, Korean, Dutch, Polish, Portuguese, Vietnamese, Chinese | ★★★★ |
 
+### GigaAM
+
+Sber's GigaAM v3 (int8 ONNX). A Conformer model trained on 700k hours of Russian speech — the most accurate option for Russian audio. The end-to-end CTC variant outputs punctuated, normalized text.
+
+| Model | Size | RAM | Languages | Accuracy |
+|---|---|---|---|---|
+| gigaam-v3 | 225 MB | 2 GB | Russian, English | ★★★★ |
+
 ### Diarization & VAD
 
 In addition to transcription models, AutoSubs downloads a speaker diarization model (~40 MB, user-selectable from the Model Manager) and a Silero VAD model (auto-downloaded for voice activity detection during transcription).


### PR DESCRIPTION
## Summary

Adds GigaAM v3 as a transcription model for Russian.

Russian is currently only covered by Whisper and by the multilingual Parakeet/Canary models, where it is one language out of 25. GigaAM v3 (Sber, MIT) is a Conformer model trained on 700k hours of Russian speech, and the e2e variant emits punctuated, normalized text. It costs 225MB on disk and ~2GB RAM, which puts it in the same weight class as Parakeet.

### How it fits the existing structure

Most of the wiring was already in place: `Engine::Gigaam` is declared in `manifest.rs`, and `model_manager.rs` already maps it to a flat `gigaam/<id>` download layout. The only missing piece was the engine wrapper, so this PR is mostly a thin adapter plus a manifest row.

- `engines/gigaam.rs` — implements `OnnxEngine` over `transcribe_rs::onnx::gigaam::GigaAMModel`, modelled on `parakeet.rs`.
- `models.json` — a `gigaam-v3` row sourced from [`istupakov/gigaam-v3-onnx`](https://huggingface.co/istupakov/gigaam-v3-onnx) (same author as the Parakeet and Canary ONNX conversions already in the manifest, MIT).
- `README.md` — a GigaAM section under Supported Models, matching the existing per-family layout.
- i18n — a `models.gigaam_v3` entry in every locale. The picker searches on resolved strings (`t(model.label)` / `t(model.description)` / `t(model.badge)`), so the copy is translated rather than left in English; otherwise a German user searching "Russisch" would get no match.

The transcribe-rs loader resolves `model[.int8].onnx` + `vocab.txt` inside the model dir, so the two repo files are renamed on download via the existing `{ path, dest }` file spec:

```
v3_e2e_ctc.int8.onnx  -> model.int8.onnx
v3_e2e_ctc_vocab.txt  -> vocab.txt
```

I checked that the loader's mel config matches the model before wiring it up: 64 banks, 320-point window, 160 hop, HTK scale, no centering, `ln` with clamping — that is what `v3_e2e_ctc.yaml` specifies and what the onnx-asr `gigaam_v3` preprocessor computes. Graph I/O (`features` / `feature_lengths` -> `log_probs`) matches too.

### Word timings

The CTC head surfaces no token timings, so the engine returns `WordTiming::Interpolated` and is deliberately absent from the `has_native_word_timestamps` list in `engine.rs` — that way the optional MMS aligner still runs and refines the boundaries.

### One behavioural change outside the new files

GigaAM was the last engine variant without a wrapper, so the `run_engine` match is now exhaustive and its unsupported-engine arm became unreachable (`warning: unreachable pattern`). I dropped the arm rather than silencing the warning: a new `Engine` variant now fails to compile until it is wired up, which is the same guard the manifest tests apply to `models.json`. Happy to restore it behind `#[allow(unreachable_patterns)]` if you would rather keep the runtime error.

### Verification

- `cargo test -p transcription-engine` — 54 passed, including `every_model_engine_has_a_wrapper` (updated for the new variant).
- `cargo check` — no new warnings.
- `tsc --noEmit` and `npm run build:web` — clean.
- End-to-end on macOS (arm64, CoreML/Metal build) through the CLI: the model downloaded, landed in the cache as `model.int8.onnx` + `vocab.txt`, and transcribed correctly with punctuation, capitalization and number normalization ("двадцать восьмое июля" -> "28 июля"). 13s of audio took 1.3s in a debug build.

For a rough comparison on the same clip, Whisper small produced two outright recognition errors where GigaAM produced none.

### Not verified

- **Windows / DirectML.** I only have macOS hardware. The wrapper goes through `load_with_directml_fallback`, so the CPU fallback path is in place, but an int8 GigaAM graph has never been exercised on DirectML here.
- **Real-world audio.** My end-to-end check used synthesized Russian speech (macOS TTS), which has unrealistically clean articulation. It proves the pipeline works, not how accurate the model is in practice.

One artefact worth mentioning: on a longer clip a VAD chunk boundary fell inside a word and the e2e normalizer turned the fragment into `23°дуC`. The same sentence transcribed on its own is correct, and Whisper (which chunks on its own 30s windows) does not split there. This looks like the general chunk-boundary issue from #703 rather than something specific to this model, but it is more visible with a normalizing model because a partial word degrades into a stray symbol rather than half a word.
