### PR TITLE
feat(models): add GigaAM Multilingual for Central Asian languages

### DIFF
--- a/AutoSubs-App/models.json
+++ b/AutoSubs-App/models.json
@@ -256,6 +256,21 @@
       "ui": { "size": "2GB", "ram": "4GB", "image": "moose.png", "accuracy": 4, "weight": 1, "languageSupport": { "kind": "restricted", "languages": ["ar", "de", "el", "en", "es", "fr", "it", "ja", "ko", "nl", "pl", "pt", "vi", "zh"] } }
     },
     {
+      "id": "gigaam-v3",
+      "engine": "gigaam",
+      "quantization": "int8",
+      "_files_comment": "The GigaAM loader resolves model[.int8].onnx and vocab.txt inside the model dir, so the repo files are renamed on download. The e2e CTC variant is used because it emits punctuated, normalized text.",
+      "source": {
+        "type": "hf",
+        "repo": "istupakov/gigaam-v3-onnx",
+        "files": [
+          { "path": "v3_e2e_ctc.int8.onnx", "dest": "model.int8.onnx" },
+          { "path": "v3_e2e_ctc_vocab.txt", "dest": "vocab.txt" }
+        ]
+      },
+      "ui": { "size": "225MB", "ram": "2GB", "image": "owl.png", "accuracy": 4, "weight": 3, "languageSupport": { "kind": "restricted", "languages": ["ru", "en"] } }
+    },
+    {
       "id": "omni-asr-1b-ctc",
       "engine": "omni_asr",
       "quantization": "fp32",

--- a/AutoSubs-App/models.json
+++ b/AutoSubs-App/models.json
@@ -271,6 +271,21 @@
       "ui": { "size": "225MB", "ram": "2GB", "image": "owl.png", "accuracy": 4, "weight": 3, "languageSupport": { "kind": "restricted", "languages": ["ru", "en"] } }
     },
     {
+      "id": "gigaam-multilingual",
+      "engine": "gigaam",
+      "quantization": "int8",
+      "_files_comment": "Same loader layout as gigaam-v3. The 600M variant is used because it beats the 220M one on every published language; unlike v3 this family only has a character-wise CTC head, so the output has no punctuation.",
+      "source": {
+        "type": "hf",
+        "repo": "istupakov/gigaam-multilingual-large-ctc-onnx",
+        "files": [
+          { "path": "multilingual_large_ctc.int8.onnx", "dest": "model.int8.onnx" },
+          { "path": "multilingual_vocab.txt", "dest": "vocab.txt" }
+        ]
+      },
+      "ui": { "size": "592MB", "ram": "3GB", "image": "globe.png", "accuracy": 4, "weight": 2, "languageSupport": { "kind": "restricted", "languages": ["ru", "kk", "ky", "uz", "en"] } }
+    },
+    {
       "id": "omni-asr-1b-ctc",
       "engine": "omni_asr",
       "quantization": "fp32",

--- a/AutoSubs-App/src-tauri/crates/transcription-engine/src/engines/gigaam.rs
+++ b/AutoSubs-App/src-tauri/crates/transcription-engine/src/engines/gigaam.rs
@@ -1,0 +1,82 @@
+//! GigaAM (Sber) Russian speech recognition backend.
+
+use crate::engines::onnx::{run_onnx_pipeline, OnnxEngine, WordTiming};
+use crate::types::{LabeledProgressFn, NewSegmentFn, ProgressType, Segment, SpeechSegment, TranscribeOptions};
+use eyre::{eyre, Result};
+use std::path::Path;
+use transcribe_rs::onnx::{
+    gigaam::{GigaAMModel, GigaAMParams},
+    Quantization,
+};
+use transcribe_rs::TranscriptionResult;
+
+pub struct GigaamEngine {
+    model: GigaAMModel,
+    params: GigaAMParams,
+}
+
+impl OnnxEngine for GigaamEngine {
+    // The Conformer encoder attends over the whole chunk, so memory grows
+    // quadratically with its length; cap it like the other ONNX engines.
+    const MAX_SEGMENT_SECONDS: f64 = 25.0;
+
+    fn load(model_path: &Path) -> Result<Self> {
+        let model = GigaAMModel::load(model_path, &Quantization::Int8)
+            .map_err(|e| eyre!("Failed to load GigaAM model: {}", e))?;
+
+        Ok(Self {
+            model,
+            params: GigaAMParams::default(),
+        })
+    }
+
+    fn transcribe_chunk(&mut self, samples: &[f32]) -> Result<TranscriptionResult> {
+        self.model
+            .transcribe_with(samples, &self.params)
+            .map_err(|e| eyre!("GigaAM transcription failed: {}", e))
+    }
+
+    // The CTC head emits no token timings, so word boundaries are spread
+    // across the chunk window and refined later by the optional aligner.
+    fn word_timing(&self) -> WordTiming {
+        WordTiming::Interpolated
+    }
+
+    fn detected_lang(&self) -> Option<String> {
+        None
+    }
+}
+
+pub async fn transcribe_gigaam(
+    model_path: &Path,
+    speech_segments: Vec<SpeechSegment>,
+    options: &TranscribeOptions,
+    use_gpu: Option<bool>,
+    progress_callback: Option<&LabeledProgressFn>,
+    new_segment_callback: Option<&NewSegmentFn>,
+    abort_callback: Option<Box<dyn Fn() -> bool + Send + Sync>>,
+) -> Result<(Vec<Segment>, Option<String>)> {
+    tracing::debug!("GigaAM transcribe called with model: {:?}", model_path);
+
+    if abort_callback.as_ref().map(|c| c()).unwrap_or(false) {
+        eyre::bail!("Transcription cancelled");
+    }
+
+    if let Some(cb) = progress_callback {
+        cb(0, ProgressType::Analyze, "progressSteps.analyze.loading");
+    }
+    let engine = crate::engines::onnx::load_with_directml_fallback(use_gpu, || GigaamEngine::load(model_path))?;
+    if let Some(cb) = progress_callback {
+        cb(100, ProgressType::Analyze, "progressSteps.analyze.loading");
+    }
+
+    run_onnx_pipeline(
+        engine,
+        speech_segments,
+        options.offset.unwrap_or(0.0),
+        progress_callback,
+        new_segment_callback,
+        abort_callback,
+    )
+    .await
+}

--- a/AutoSubs-App/src-tauri/crates/transcription-engine/src/engines/mod.rs
+++ b/AutoSubs-App/src-tauri/crates/transcription-engine/src/engines/mod.rs
@@ -5,6 +5,7 @@
 //! - **Parakeet**: NVIDIA's NeMo Parakeet model via transcribe-rs (ONNX format)
 //! - **Moonshine**: Useful Sensors' Moonshine via transcribe-rs (ONNX format)
 //! - **SenseVoice**: FunAudioLLM SenseVoice via transcribe-rs (ONNX format)
+//! - **GigaAM**: Sber's Russian GigaAM v3 CTC via transcribe-rs (ONNX format)
 //! - **OmniAsr**: Facebook Omni-ASR 300M CTC via ORT (ONNX format)
 
 use crate::engine::EngineConfig;
@@ -18,6 +19,7 @@ pub mod whisper;
 pub mod onnx;
 pub mod canary;
 pub mod cohere;
+pub mod gigaam;
 pub mod moonshine;
 pub mod omni_asr;
 pub mod parakeet;
@@ -28,6 +30,7 @@ pub use whisper::{create_context, run_transcription_pipeline, SHOULD_CANCEL};
 
 pub use canary::transcribe_canary;
 pub use cohere::transcribe_cohere;
+pub use gigaam::transcribe_gigaam;
 pub use moonshine::transcribe_moonshine;
 pub use parakeet::transcribe_parakeet;
 pub use omni_asr::transcribe_omni_asr;
@@ -149,6 +152,18 @@ pub async fn run_engine(
             )
             .await
         }
+        ModelEngine::Gigaam => {
+            crate::engines::gigaam::transcribe_gigaam(
+                model_path,
+                speech_segments,
+                options,
+                use_gpu,
+                progress,
+                new_segment_callback,
+                abort_callback,
+            )
+            .await
+        }
         ModelEngine::OmniAsr => {
             crate::engines::omni_asr::transcribe_omni_asr(
                 model_path,
@@ -161,10 +176,5 @@ pub async fn run_engine(
             )
             .await
         }
-        other => Err(eyre!(
-            "Transcription engine {:?} (model '{}') is not yet supported",
-            other,
-            options.model
-        )),
     }
 }

--- a/AutoSubs-App/src-tauri/crates/transcription-engine/src/manifest.rs
+++ b/AutoSubs-App/src-tauri/crates/transcription-engine/src/manifest.rs
@@ -379,6 +379,7 @@ mod tests {
                         | Engine::SenseVoice
                         | Engine::Canary
                         | Engine::Cohere
+                        | Engine::Gigaam
                         | Engine::OmniAsr
                 ),
                 "model '{}' uses engine {:?} which has no wrapper yet",

--- a/AutoSubs-App/src-tauri/src/cli.rs
+++ b/AutoSubs-App/src-tauri/src/cli.rs
@@ -46,6 +46,7 @@ const MODELS: &[&str] = &[
     "parakeet",
     // GigaAM
     "gigaam-v3",
+    "gigaam-multilingual",
     // Omni-ASR
     "omni-asr-1b-ctc",
     // Moonshine

--- a/AutoSubs-App/src-tauri/src/cli.rs
+++ b/AutoSubs-App/src-tauri/src/cli.rs
@@ -44,6 +44,8 @@ const MODELS: &[&str] = &[
     "large-v3",
     // Parakeet
     "parakeet",
+    // GigaAM
+    "gigaam-v3",
     // Omni-ASR
     "omni-asr-1b-ctc",
     // Moonshine

--- a/AutoSubs-App/src/i18n/locales/de/translation.json
+++ b/AutoSubs-App/src/i18n/locales/de/translation.json
@@ -380,9 +380,9 @@
     },
     "gigaam_v3": {
       "label": "GigaAM v3",
-      "description": "Best for Russian",
-      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
-      "badge": "Russian"
+      "description": "Am besten für Russisch",
+      "details": "Trainiert mit 700.000 Stunden russischer Sprache, mit Zeichensetzung und Textnormalisierung. Die genaueste Option für Russisch.",
+      "badge": "Russisch"
     },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",

--- a/AutoSubs-App/src/i18n/locales/de/translation.json
+++ b/AutoSubs-App/src/i18n/locales/de/translation.json
@@ -378,6 +378,12 @@
       "details": "Großes mehrsprachiges Transkriptionsmodell von Cohere.",
       "badge": "Mehrsprachig"
     },
+    "gigaam_v3": {
+      "label": "GigaAM v3",
+      "description": "Best for Russian",
+      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
+      "badge": "Russian"
+    },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",
       "description": "On-device Multilingual",

--- a/AutoSubs-App/src/i18n/locales/de/translation.json
+++ b/AutoSubs-App/src/i18n/locales/de/translation.json
@@ -384,6 +384,12 @@
       "details": "Trainiert mit 700.000 Stunden russischer Sprache, mit Zeichensetzung und Textnormalisierung. Die genaueste Option für Russisch.",
       "badge": "Russisch"
     },
+    "gigaam_multilingual": {
+      "label": "GigaAM Multilingual",
+      "description": "Zentralasiatisch & Russisch",
+      "details": "Beste offene Qualität für Kasachisch, Kirgisisch und Usbekisch, stark auch bei Russisch. Gibt Kleinbuchstaben ohne Zeichensetzung aus.",
+      "badge": "Mehrsprachig"
+    },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",
       "description": "On-device Multilingual",

--- a/AutoSubs-App/src/i18n/locales/en/translation.json
+++ b/AutoSubs-App/src/i18n/locales/en/translation.json
@@ -388,6 +388,12 @@
       "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
       "badge": "Russian"
     },
+    "gigaam_multilingual": {
+      "label": "GigaAM Multilingual",
+      "description": "Central Asian & Russian",
+      "details": "Best open quality for Kazakh, Kyrgyz and Uzbek, and strong on Russian. Outputs lowercase text without punctuation.",
+      "badge": "Multilingual"
+    },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",
       "description": "On-device Multilingual",

--- a/AutoSubs-App/src/i18n/locales/en/translation.json
+++ b/AutoSubs-App/src/i18n/locales/en/translation.json
@@ -382,6 +382,12 @@
       "details": "Large multilingual transcription model from Cohere.",
       "badge": "Multilingual"
     },
+    "gigaam_v3": {
+      "label": "GigaAM v3",
+      "description": "Best for Russian",
+      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
+      "badge": "Russian"
+    },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",
       "description": "On-device Multilingual",

--- a/AutoSubs-App/src/i18n/locales/es/translation.json
+++ b/AutoSubs-App/src/i18n/locales/es/translation.json
@@ -384,6 +384,12 @@
       "details": "Entrenado con 700 000 horas de habla rusa, con puntuación y normalización de texto. La opción más precisa para el ruso.",
       "badge": "Ruso"
     },
+    "gigaam_multilingual": {
+      "label": "GigaAM Multilingual",
+      "description": "Asia Central y ruso",
+      "details": "La mejor calidad abierta para kazajo, kirguís y uzbeko, y muy buena en ruso. Devuelve texto en minúsculas sin puntuación.",
+      "badge": "Multilingüe"
+    },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",
       "description": "On-device Multilingual",

--- a/AutoSubs-App/src/i18n/locales/es/translation.json
+++ b/AutoSubs-App/src/i18n/locales/es/translation.json
@@ -380,9 +380,9 @@
     },
     "gigaam_v3": {
       "label": "GigaAM v3",
-      "description": "Best for Russian",
-      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
-      "badge": "Russian"
+      "description": "Ideal para ruso",
+      "details": "Entrenado con 700 000 horas de habla rusa, con puntuación y normalización de texto. La opción más precisa para el ruso.",
+      "badge": "Ruso"
     },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",

--- a/AutoSubs-App/src/i18n/locales/es/translation.json
+++ b/AutoSubs-App/src/i18n/locales/es/translation.json
@@ -378,6 +378,12 @@
       "details": "Modelo grande de transcripción multilingüe de Cohere.",
       "badge": "Multilingüe"
     },
+    "gigaam_v3": {
+      "label": "GigaAM v3",
+      "description": "Best for Russian",
+      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
+      "badge": "Russian"
+    },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",
       "description": "On-device Multilingual",

--- a/AutoSubs-App/src/i18n/locales/fr/translation.json
+++ b/AutoSubs-App/src/i18n/locales/fr/translation.json
@@ -384,6 +384,12 @@
       "details": "Entraîné sur 700 000 heures de parole russe, avec ponctuation et normalisation du texte. L'option la plus précise pour le russe.",
       "badge": "Russe"
     },
+    "gigaam_multilingual": {
+      "label": "GigaAM Multilingual",
+      "description": "Asie centrale et russe",
+      "details": "Meilleure qualité ouverte pour le kazakh, le kirghize et l'ouzbek, et solide en russe. Produit un texte en minuscules sans ponctuation.",
+      "badge": "Multilingue"
+    },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",
       "description": "On-device Multilingual",

--- a/AutoSubs-App/src/i18n/locales/fr/translation.json
+++ b/AutoSubs-App/src/i18n/locales/fr/translation.json
@@ -378,6 +378,12 @@
       "details": "Grand modèle de transcription multilingue de Cohere.",
       "badge": "Multilingue"
     },
+    "gigaam_v3": {
+      "label": "GigaAM v3",
+      "description": "Best for Russian",
+      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
+      "badge": "Russian"
+    },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",
       "description": "On-device Multilingual",

--- a/AutoSubs-App/src/i18n/locales/fr/translation.json
+++ b/AutoSubs-App/src/i18n/locales/fr/translation.json
@@ -380,9 +380,9 @@
     },
     "gigaam_v3": {
       "label": "GigaAM v3",
-      "description": "Best for Russian",
-      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
-      "badge": "Russian"
+      "description": "Idéal pour le russe",
+      "details": "Entraîné sur 700 000 heures de parole russe, avec ponctuation et normalisation du texte. L'option la plus précise pour le russe.",
+      "badge": "Russe"
     },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",

--- a/AutoSubs-App/src/i18n/locales/ja/translation.json
+++ b/AutoSubs-App/src/i18n/locales/ja/translation.json
@@ -384,6 +384,12 @@
       "details": "70万時間のロシア語音声で学習。句読点とテキスト正規化に対応した、ロシア語で最も高精度な選択肢。",
       "badge": "ロシア語"
     },
+    "gigaam_multilingual": {
+      "label": "GigaAM Multilingual",
+      "description": "中央アジア言語・ロシア語",
+      "details": "カザフ語、キルギス語、ウズベク語でオープンモデル最高水準の精度、ロシア語にも強い。句読点なしの小文字テキストを出力します。",
+      "badge": "多言語"
+    },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",
       "description": "On-device Multilingual",

--- a/AutoSubs-App/src/i18n/locales/ja/translation.json
+++ b/AutoSubs-App/src/i18n/locales/ja/translation.json
@@ -378,6 +378,12 @@
       "details": "Cohere の大型多言語文字起こしモデル。",
       "label": "Cohere"
     },
+    "gigaam_v3": {
+      "label": "GigaAM v3",
+      "description": "Best for Russian",
+      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
+      "badge": "Russian"
+    },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",
       "description": "On-device Multilingual",

--- a/AutoSubs-App/src/i18n/locales/ja/translation.json
+++ b/AutoSubs-App/src/i18n/locales/ja/translation.json
@@ -380,9 +380,9 @@
     },
     "gigaam_v3": {
       "label": "GigaAM v3",
-      "description": "Best for Russian",
-      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
-      "badge": "Russian"
+      "description": "ロシア語に最適",
+      "details": "70万時間のロシア語音声で学習。句読点とテキスト正規化に対応した、ロシア語で最も高精度な選択肢。",
+      "badge": "ロシア語"
     },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",

--- a/AutoSubs-App/src/i18n/locales/ko/translation.json
+++ b/AutoSubs-App/src/i18n/locales/ko/translation.json
@@ -384,6 +384,12 @@
       "details": "70만 시간의 러시아어 음성으로 학습. 문장 부호와 텍스트 정규화를 지원하는 러시아어에 가장 정확한 모델.",
       "badge": "러시아어"
     },
+    "gigaam_multilingual": {
+      "label": "GigaAM Multilingual",
+      "description": "중앙아시아 언어 및 러시아어",
+      "details": "카자흐어, 키르기스어, 우즈베크어에서 최고 수준의 오픈 모델 정확도를 제공하며 러시아어에도 강합니다. 문장 부호 없는 소문자 텍스트를 출력합니다.",
+      "badge": "다국어"
+    },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",
       "description": "On-device Multilingual",

--- a/AutoSubs-App/src/i18n/locales/ko/translation.json
+++ b/AutoSubs-App/src/i18n/locales/ko/translation.json
@@ -378,6 +378,12 @@
       "details": "Cohere의 대형 다국어 자막 생성 모델.",
       "label": "Cohere"
     },
+    "gigaam_v3": {
+      "label": "GigaAM v3",
+      "description": "Best for Russian",
+      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
+      "badge": "Russian"
+    },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",
       "description": "On-device Multilingual",

--- a/AutoSubs-App/src/i18n/locales/ko/translation.json
+++ b/AutoSubs-App/src/i18n/locales/ko/translation.json
@@ -380,9 +380,9 @@
     },
     "gigaam_v3": {
       "label": "GigaAM v3",
-      "description": "Best for Russian",
-      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
-      "badge": "Russian"
+      "description": "러시아어에 최적",
+      "details": "70만 시간의 러시아어 음성으로 학습. 문장 부호와 텍스트 정규화를 지원하는 러시아어에 가장 정확한 모델.",
+      "badge": "러시아어"
     },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",

--- a/AutoSubs-App/src/i18n/locales/zh/translation.json
+++ b/AutoSubs-App/src/i18n/locales/zh/translation.json
@@ -378,6 +378,12 @@
       "details": "Cohere 的大型多语言转录模型。",
       "badge": "多语言"
     },
+    "gigaam_v3": {
+      "label": "GigaAM v3",
+      "description": "Best for Russian",
+      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
+      "badge": "Russian"
+    },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",
       "description": "On-device Multilingual",

--- a/AutoSubs-App/src/i18n/locales/zh/translation.json
+++ b/AutoSubs-App/src/i18n/locales/zh/translation.json
@@ -384,6 +384,12 @@
       "details": "基于 70 万小时俄语语音训练，支持标点和文本规范化。俄语的最准确选择。",
       "badge": "俄语"
     },
+    "gigaam_multilingual": {
+      "label": "GigaAM Multilingual",
+      "description": "中亚语言与俄语",
+      "details": "在哈萨克语、吉尔吉斯语和乌兹别克语上具有开源模型的最佳质量，俄语表现也很强。输出不含标点的小写文本。",
+      "badge": "多语言"
+    },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",
       "description": "On-device Multilingual",

--- a/AutoSubs-App/src/i18n/locales/zh/translation.json
+++ b/AutoSubs-App/src/i18n/locales/zh/translation.json
@@ -380,9 +380,9 @@
     },
     "gigaam_v3": {
       "label": "GigaAM v3",
-      "description": "Best for Russian",
-      "details": "Trained on 700k hours of Russian speech, with punctuation and text normalization. The most accurate option for Russian.",
-      "badge": "Russian"
+      "description": "俄语最佳",
+      "details": "基于 70 万小时俄语语音训练，支持标点和文本规范化。俄语的最准确选择。",
+      "badge": "俄语"
     },
     "omni_asr_1b_ctc": {
       "label": "Omni-ASR",

--- a/AutoSubs-App/src/lib/models.ts
+++ b/AutoSubs-App/src/lib/models.ts
@@ -88,21 +88,21 @@ export const modelFilterOrders = {
     // 2GB RAM
     "small.en", "small", "parakeet", "gigaam-v3",
     // 3-4GB RAM
-    "canary", "cohere", "omni-asr-1b-ctc",
+    "canary", "gigaam-multilingual", "cohere", "omni-asr-1b-ctc",
     // 5-6GB RAM
     "medium.en", "medium", "large-v3-turbo",
     // 10GB RAM
     "large-v3"
   ],
   accuracy: [
-    "cohere", "parakeet", "canary", "gigaam-v3", "large-v3", "large-v3-turbo",
+    "cohere", "parakeet", "canary", "gigaam-v3", "gigaam-multilingual", "large-v3", "large-v3-turbo",
     "moonshine-tiny-vi", "moonshine-tiny-ar", "moonshine-tiny-zh", "moonshine-tiny-ja", "moonshine-tiny-ko", "medium.en", "medium",
     "sense-voice", "moonshine-base", "small.en", "small", "moonshine-tiny-uk",
     "omni-asr-1b-ctc",
     "tiny", "tiny.en", "base", "base.en", "moonshine-tiny"
   ],
   recommended: [
-    "parakeet", "canary", "sense-voice", "gigaam-v3", "omni-asr-1b-ctc", "cohere", "large-v3-turbo", "large-v3",
+    "parakeet", "canary", "sense-voice", "gigaam-v3", "gigaam-multilingual", "omni-asr-1b-ctc", "cohere", "large-v3-turbo", "large-v3",
     "moonshine-tiny-ar", "moonshine-tiny-zh", "moonshine-tiny-ja", "moonshine-tiny-ko", "moonshine-tiny-uk", "moonshine-tiny-vi",
     "moonshine-base", "small.en", "small",
     "medium", "medium.en",

--- a/AutoSubs-App/src/lib/models.ts
+++ b/AutoSubs-App/src/lib/models.ts
@@ -86,7 +86,7 @@ export const modelFilterOrders = {
     "moonshine-tiny-ko", "moonshine-tiny-uk", "moonshine-tiny-vi",
     "moonshine-base", "sense-voice",
     // 2GB RAM
-    "small.en", "small", "parakeet",
+    "small.en", "small", "parakeet", "gigaam-v3",
     // 3-4GB RAM
     "canary", "cohere", "omni-asr-1b-ctc",
     // 5-6GB RAM
@@ -95,14 +95,14 @@ export const modelFilterOrders = {
     "large-v3"
   ],
   accuracy: [
-    "cohere", "parakeet", "canary", "large-v3", "large-v3-turbo",
+    "cohere", "parakeet", "canary", "gigaam-v3", "large-v3", "large-v3-turbo",
     "moonshine-tiny-vi", "moonshine-tiny-ar", "moonshine-tiny-zh", "moonshine-tiny-ja", "moonshine-tiny-ko", "medium.en", "medium",
     "sense-voice", "moonshine-base", "small.en", "small", "moonshine-tiny-uk",
     "omni-asr-1b-ctc",
     "tiny", "tiny.en", "base", "base.en", "moonshine-tiny"
   ],
   recommended: [
-    "parakeet", "canary", "sense-voice", "omni-asr-1b-ctc", "cohere", "large-v3-turbo", "large-v3",
+    "parakeet", "canary", "sense-voice", "gigaam-v3", "omni-asr-1b-ctc", "cohere", "large-v3-turbo", "large-v3",
     "moonshine-tiny-ar", "moonshine-tiny-zh", "moonshine-tiny-ja", "moonshine-tiny-ko", "moonshine-tiny-uk", "moonshine-tiny-vi",
     "moonshine-base", "small.en", "small",
     "medium", "medium.en",

--- a/README.md
+++ b/README.md
@@ -159,6 +159,14 @@ Cohere Transcribe (int4 ONNX). The highest-accuracy option for a focused set of 
 |---|---|---|---|---|
 | cohere | 2 GB | 4 GB | Arabic, German, Greek, English, Spanish, French, Italian, Japanese, Korean, Dutch, Polish, Portuguese, Vietnamese, Chinese | ★★★★ |
 
+### GigaAM
+
+Sber's GigaAM v3 (int8 ONNX). A Conformer model trained on 700k hours of Russian speech — the most accurate option for Russian audio. The end-to-end CTC variant outputs punctuated, normalized text.
+
+| Model | Size | RAM | Languages | Accuracy |
+|---|---|---|---|---|
+| gigaam-v3 | 225 MB | 2 GB | Russian, English | ★★★★ |
+
 ### Diarization & VAD
 
 In addition to transcription models, AutoSubs downloads a speaker diarization model (~40 MB, user-selectable from the Model Manager) and a Silero VAD model (auto-downloaded for voice activity detection during transcription).

--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ Sber's GigaAM v3 (int8 ONNX). A Conformer model trained on 700k hours of Russian
 |---|---|---|---|---|
 | gigaam-v3 | 225 MB | 2 GB | Russian, English | ★★★★ |
 
+GigaAM Multilingual (600M, int8 ONNX) covers Central Asian languages that the other models handle poorly — Whisper large v3 scores 58–110% WER on Kazakh, Kyrgyz and Uzbek. It uses a character-wise CTC head, so unlike GigaAM v3 its output has no punctuation or capitalization.
+
+| Model | Size | RAM | Languages | Accuracy |
+|---|---|---|---|---|
+| gigaam-multilingual | 592 MB | 3 GB | Russian, Kazakh, Kyrgyz, Uzbek, English | ★★★★ |
+
 ### Diarization & VAD
 
 In addition to transcription models, AutoSubs downloads a speaker diarization model (~40 MB, user-selectable from the Model Manager) and a Silero VAD model (auto-downloaded for voice activity detection during transcription).


### PR DESCRIPTION
> **Depends on #723** — that PR adds the `gigaam` engine wrapper this model loads through. Until it merges, the diff here also shows its commits; it will collapse to a single commit once #723 lands. Happy to rebase whenever suits you.

## Summary

Adds GigaAM Multilingual (600M, int8 ONNX, MIT) — a Conformer model pre-trained on 2M hours across 70+ languages and fine-tuned for ASR, released two weeks ago.

The motivation is coverage rather than raw accuracy. Kazakh, Kyrgyz and Uzbek are effectively unusable with the current catalog, and this model is the strongest open option for them by a wide margin. WER on Common Voice, from the model card:

| Language | Multilingual 600M | Omni-ASR 1B | Whisper large v3 |
|---|---|---|---|
| Kazakh | **13.8** | 23.7 | 57.8 |
| Kyrgyz | **10.2** | 21.6 | 95.2 |
| Uzbek | **9.2** | 32.8 | 109.9 |
| Russian | **5.1** | 13.6 | 9.1 |

Omni-ASR is the only model already in the manifest that covers these languages; this one beats it on every published row at 592MB instead of 3.7GB.

### Why the 600M variant

The family ships 220M and 600M. The larger one wins on every published row, and 220M would add little on its own: it loses to `gigaam-v3` on Russian and, like the whole family, produces no punctuation.

### No engine changes

The preprocessor config is identical to v3 (64 banks, 320-point window, 160 hop, no centering) and the file layout matches, so the `gigaam` wrapper from #723 loads it unchanged — this PR is a manifest row, i18n copy and a README section.

### Tradeoff worth knowing before merging

This family only has a character-wise CTC head. Unlike `gigaam-v3`, the output is lowercase, unpunctuated, and numbers stay spelled out — the model card's own metrics are computed after lowercasing and stripping punctuation, which reflects what the model emits. On the same clip:

```
gigaam-v3:           Сегодня 28 июля, температура 23°C.
gigaam-multilingual: сегодня двадцать восьмое июля температура двадцать три градуса
```

For subtitles that is a real regression, so the two models are complementary rather than a replacement: v3 stays the pick for Russian, this one exists for the languages nothing else covers. The details string says so explicitly, so it is visible in the picker before a 592MB download.

### Verification

- `cargo test -p transcription-engine` — 54 passed. `tsc --noEmit` clean.
- End-to-end on macOS (arm64) through the CLI: model downloaded, cached as `model.int8.onnx` + `vocab.txt`, transcribed Russian correctly word-for-word (13s of audio in 2.7s wall clock, debug build).

### Not verified

- **Kazakh, Kyrgyz, Uzbek.** I do not speak these languages and have no test material for them, so the coverage claim rests on the published metrics rather than on my own measurement.
- **Windows / DirectML**, same as #723 — macOS hardware only.
- Real-world audio: my check used synthesized Russian speech, which is unrealistically clean.
