### PR TITLE
fix(resolve): integerize caption frames for AppendToTimeline

### DIFF
--- a/AutoSubs-App/src-tauri/resources/modules/autosubs_core.lua
+++ b/AutoSubs-App/src-tauri/resources/modules/autosubs_core.lua
@@ -1749,13 +1749,13 @@ function GeneratePreview(speaker, templateName, presetSettings, exportDir, langu
     end
 
     local trackIndex = timeline:GetTrackCount("video")
-    local fps = templateItem:GetClipProperty()["FPS"]
+    local fps = tonumber(templateItem:GetClipProperty()["FPS"]) or 24
 
     local appendOk, appended = pcall(function()
         return mediaPool:AppendToTimeline({ {
             mediaPoolItem = templateItem,
             startFrame = 0,
-            endFrame = fps * 5, -- set preview to 5 seconds long
+            endFrame = math.floor(fps * 5), -- 5-second preview clip
             recordFrame = timeline:GetStartFrame(),
             trackIndex = trackIndex
         } })

--- a/AutoSubs-App/src-tauri/resources/modules/autosubs_core.lua
+++ b/AutoSubs-App/src-tauri/resources/modules/autosubs_core.lua
@@ -1351,15 +1351,20 @@ local function build_clip_list(subtitles, speakers, speakersExist, trackIndex, t
                 i, tostring(subtitle["start"]), tostring(subtitle["end"])))
             goto continue
         end
-        local start_frame = to_frames(subtitle["start"], frame_rate)
-        local end_frame = to_frames(subtitle["end"], frame_rate)
+        -- Resolve 21 AppendToTimeline rejects non-integer frame values and
+        -- returns nil for the whole batch. Snap to nearest timeline frame.
+        local start_frame = math.floor(to_frames(subtitle["start"], frame_rate) + 0.5)
+        local end_frame = math.floor(to_frames(subtitle["end"], frame_rate) + 0.5)
+        if end_frame <= start_frame then
+            end_frame = start_frame + 1
+        end
         local timeline_pos = timelineStart + start_frame
         local clip_timeline_duration = end_frame - start_frame
 
         if i < #subtitles then
             local nextSub = subtitles[i + 1]
             if nextSub and nextSub["start"] ~= nil then
-                local next_start = timelineStart + to_frames(nextSub["start"], frame_rate)
+                local next_start = timelineStart + math.floor(to_frames(nextSub["start"], frame_rate) + 0.5)
                 local frames_between = next_start - (timeline_pos + clip_timeline_duration)
                 if frames_between < joinThreshold then
                     clip_timeline_duration = clip_timeline_duration + frames_between + 1
@@ -1367,7 +1372,8 @@ local function build_clip_list(subtitles, speakers, speakersExist, trackIndex, t
             end
         end
 
-        local duration = (clip_timeline_duration / frame_rate) * template_frame_rate
+        -- endFrame is template-relative source frames, not timeline frames.
+        local duration = math.max(1, math.floor((clip_timeline_duration / frame_rate) * template_frame_rate + 0.5))
 
         local itemTrack = trackIndex
         if speakersExist then
@@ -1382,7 +1388,7 @@ local function build_clip_list(subtitles, speakers, speakersExist, trackIndex, t
             mediaType = 1,
             startFrame = 0,
             endFrame = duration,
-            recordFrame = timeline_pos,
+            recordFrame = math.floor(timeline_pos + 0.5),
             trackIndex = itemTrack
         }
 


### PR DESCRIPTION
## Summary
- Fixes Add to Timeline silently dropping all captions when word-level timings produce fractional `recordFrame` / `endFrame` values. Resolve 21's `AppendToTimeline` rejects the whole batch and returns `nil`.
- Snap caption start/end to the nearest timeline frame, keep a 1-frame minimum so very short words still place, and integerize template-relative `endFrame`.
- Apply the same integer `endFrame` contract to `GeneratePreview` (matches the working `StartPresetEdit` path).

Fixes #745

## Test plan
- [x] Transcribe with Text Density set to Single Word
- [x] Send to Timeline in DaVinci Resolve 21 (macOS Apple Silicon)
- [x] Confirm word captions are placed (not an empty track)
- [x] Confirm very short words still appear as clips
- [ ] Spot-check a few words against spoken audio (alignment within ~1 frame)
- [ ] Generate a template preview and confirm it still renders


Made with [Cursor](https://cursor.com)